### PR TITLE
Simplify handling of errors from _remote_debugging

### DIFF
--- a/src/gcmon/monitor.py
+++ b/src/gcmon/monitor.py
@@ -58,20 +58,7 @@ class EventsMonitor:
             return PollStatus.OK
         except RuntimeError as exc:
             logger.debug("Error while polling PID %s (child PID=%s): %s", self._process.pid, pid, exc)
-            s = str(exc)
-            match s:
-                case "Failed to initialize process handle":
-                    return PollStatus.INVALID_PROCESS
-                case "Failed to get Python runtime address":
-                    return PollStatus.INVALID_PROCESS
-                case "Failed to read debug offsets":
-                    return PollStatus.INVALID_PROCESS
-                case "Invalid debug offsets found":
-                    return PollStatus.INVALID_PYTHON
-                case "No interpreter state found":
-                    return PollStatus.INVALID_PROCESS
-                case _:
-                    return PollStatus.FAIL
+            return PollStatus.INVALID_PROCESS
         except PermissionError as exc:
             logger.debug("Error while polling PID %s (child PID=%s): %s", self._process.pid, pid, exc)
             return PollStatus.INVALID_PROCESS

--- a/src/gcmon/poll_status.py
+++ b/src/gcmon/poll_status.py
@@ -6,4 +6,3 @@ class PollStatus(IntEnum):
     OK = auto()
     FAIL = auto()
     INVALID_PROCESS = auto()
-    INVALID_PYTHON = auto()

--- a/src/gcmon/wait_policy.py
+++ b/src/gcmon/wait_policy.py
@@ -43,8 +43,6 @@ class StartupTimeoutPolicy(WaitPolicy):
                 return True
             case PollStatus.FAIL:
                 return False
-            case PollStatus.INVALID_PYTHON:
-                return False
             case PollStatus.INVALID_PROCESS:
                 if not self._has_seen_alive:
                     # Process hasn't started yet — wait with timeout

--- a/tests/test_monitor_thread.py
+++ b/tests/test_monitor_thread.py
@@ -65,8 +65,8 @@ class TestGCMonitor:
         (PollStatus.INVALID_PROCESS, "Failed to initialize process handle"),
         (PollStatus.INVALID_PROCESS, "Failed to get Python runtime address"),
         (PollStatus.INVALID_PROCESS, "Failed to read debug offsets"),
-        (PollStatus.INVALID_PYTHON, "Invalid debug offsets found"),
-        (PollStatus.FAIL, "Some other error"),
+        (PollStatus.INVALID_PROCESS, "Invalid debug offsets found"),
+        (PollStatus.INVALID_PROCESS, "Some other error"),
     ])
     def test_poll_runtime_error(self, monitor: EventsMonitor, expected_status: PollStatus, error_msg: str) -> None:
         with patch("gcmon.monitor.get_gc_stats", side_effect=RuntimeError(error_msg)):

--- a/tests/test_poll_status.py
+++ b/tests/test_poll_status.py
@@ -14,7 +14,6 @@ class TestPollStatusMembers:
             PollStatus.OK,
             PollStatus.FAIL,
             PollStatus.INVALID_PROCESS,
-            PollStatus.INVALID_PYTHON,
         ]
 
     def test_repr(self):

--- a/tests/test_wait_policy.py
+++ b/tests/test_wait_policy.py
@@ -23,7 +23,7 @@ class TestNoWaitPolicy:
     def test_ok_returns_true(self, no_wait_policy):
         assert no_wait_policy.wait(PollStatus.OK) is True
 
-    @pytest.mark.parametrize("status", [PollStatus.FAIL, PollStatus.INVALID_PROCESS, PollStatus.INVALID_PYTHON])
+    @pytest.mark.parametrize("status", [PollStatus.FAIL, PollStatus.INVALID_PROCESS])
     def test_others_return_false(self, no_wait_policy, status):
         assert no_wait_policy.wait(status) is False
 
@@ -36,9 +36,6 @@ class TestStartupTimeoutPolicy:
 
     def test_fail_returns_false(self, make_policy):
         assert make_policy().wait(PollStatus.FAIL) is False
-
-    def test_invalid_python_returns_false(self, make_policy):
-        assert make_policy().wait(PollStatus.INVALID_PYTHON) is False
 
     def test_invalid_process_before_timeout(self, make_policy):
         with patch("time.monotonic", side_effect=[100.0, 103.0]):


### PR DESCRIPTION
Due to race conditions during the child process's runtime initialization, we may encounter unpredictable `RuntimeErrors`. Rather than attempting to handle every specific case, we should implement a broader, simplified error-handling strategy.