### PR TITLE
Strip internal symbol names from ADRs 0001-0014

### DIFF
--- a/docs/adr/0001-hand-rolled-perfetto-protobuf-encoder.md
+++ b/docs/adr/0001-hand-rolled-perfetto-protobuf-encoder.md
@@ -18,7 +18,7 @@ The cost is owning those field numbers against a proto that changes upstream. Th
 field-number bugs have shipped: `TrackEvent.type` and `track_uuid` renumbered upstream,
 timestamps written inside `TrackEvent` where field 1 is a `timestamp_delta_us` oneof
 member, and `DebugAnnotation.name` moving from field 1 to field 10 (field 1 is now a
-`uint64` interned ID). A fourth was arithmetic: `encode_varint` masked to 32 bits, so
+`uint64` interned ID). A fourth was arithmetic: the varint encoder masked to 32 bits, so
 `sibling_order_rank = -1` was written as `0`.
 
 All four fail the same way. The trace still parses; it renders wrong, and only a human
@@ -57,12 +57,9 @@ Helpers shared by more than one of them live in `tests/exporters/perfetto_helper
 Three rules make this safe:
 
 - **Every protobuf field number is a named `IntEnum` member**, one enum class per proto
-  message: `TraceField`, `TracePacketField`, `TrackDescriptorField`, `ProcessDescriptorField`,
-  `ThreadDescriptorField`, `CounterDescriptorField`, `TrackEventField`, `DebugAnnotationField`,
-  plus the value enums `ChildTracksOrdering`, `ProcessOrdering`, `ThreadOrdering`,
-  `TrackEventType`. `IntEnum` members are `int` subclasses, so they pass anywhere an `int`
-  is expected at zero runtime cost. All are exported via `__all__`. A future upstream
-  renumbering is one edit per field, in one file.
+  message, with the ordering and event-type value enums alongside them. `IntEnum` members
+  are `int` subclasses, so they pass anywhere an `int` is expected at zero runtime cost. A
+  future upstream renumbering is one edit per field, in one file.
 - **Timestamps live on `TracePacket.timestamp` (field 8), never inside `TrackEvent`.**
 - **Every `TracePacket` carries `trusted_packet_sequence_id` (field 10, uint32).**
   Perfetto drops packets without it, since it needs the sequence for incremental state
@@ -85,17 +82,16 @@ the runtime tree. Sub-messages are built field-by-field using the local encoder 
   correct and an incorrect value; it would not have caught any of the field-number bugs
   above.
   The end-to-end guard is ADR-0014's trace-processor tests.
-- The `DebugAnnotationField.NAME = 10` constant carries an inline comment explaining the
-  oneof constraint and warning against "fixing" it back to 1. Keep that comment.
-- Byte-level parity with the official package was verified once: for a full 1450-event GC
-  trace, both encoders produced identical output (162,793 bytes, zero differences), and
-  the trace processor reported matching rows across the `track`, `process`, `thread`,
-  `slice`, and `counter` tables.
+- The constant for `DebugAnnotation.name` carries an inline comment explaining the oneof
+  constraint and warning against "fixing" it back to 1. Keep that comment.
+- Byte-level parity with the official package was verified once: over a full GC trace both
+  encoders produced identical output, and the trace processor reported matching rows
+  across the `track`, `process`, `thread`, `slice`, and `counter` tables.
 - **Prove a no-behaviour-change refactor by comparing emitted bytes, not by a green
   suite.** Some tests assert packets are present without asserting order, and order is
-  load-bearing on the `Processes` track. Pass an explicit `sequence_id`, or the default
-  `id(self) & 0x7FFFFFFF` changes every run and swamps the comparison. This is how the
-  five-module split was verified.
+  load-bearing on the `Processes` track. Pin the sequence id explicitly, or the default
+  derived from the encoder instance changes every run and swamps the comparison. This is
+  how the five-module split was verified.
 
 ## Alternatives considered
 
@@ -103,22 +99,20 @@ the runtime tree. Sub-messages are built field-by-field using the local encoder 
   install for the process being monitored, for a serialization job that is a few hundred
   lines of well-specified wire format.
 - **Interned annotation names (`name_iid` + a name table).** Rejected as premature: it is
-  an optimization for high-frequency annotation writers, and gcmon emits one `BeginEvent`
-  per GC pause. The bandwidth saving is negligible and it would add state to the encoder.
+  an optimization for high-frequency annotation writers, and gcmon emits one slice per GC
+  pause. The bandwidth saving is negligible and it would add state to the encoder.
 - **A back-compat shim writing `DebugAnnotation.name` at both field 1 and field 10.**
   Rejected: field 1 is now a `uint64` IID. A string written there is either dropped or
   read as a garbage IID that could collide with a real interned name.
 
 ## Implementation
 
-- `src/gcmon/exporters/protobuf_encoder.py:21`, `encode_varint`, with 64-bit sign
-  extension for negative values; `:44`, `encode_varint_field`.
-- `src/gcmon/exporters/perfetto_proto.py`, every field enum: `TrackDescriptorField`,
-  `CounterDescriptorField.Y_AXIS_SHARE_KEY`, `ProcessDescriptorField`, and
-  `DebugAnnotationField.NAME = 10` with its warning comment.
-- `src/gcmon/exporters/perfetto_builders.py`, `build_track_descriptor`, which builds each
-  sub-message field-by-field.
-- Wire-level regression tests: `tests/exporters/test_perfetto_builders.py` (assertions on
-  raw field numbers and wire types, not round-trips), and
-  `tests/exporters/test_perfetto_proto.py`, which reads the numbers back out of the
-  `perfetto` package's generated descriptors rather than trusting our own.
+- `src/gcmon/exporters/protobuf_encoder.py` holds the wire primitives, with 64-bit sign
+  extension so a negative value encodes in full rather than being masked to 32 bits.
+- `src/gcmon/exporters/perfetto_proto.py` holds every field number and enum value, and
+  nothing else, including `DebugAnnotation.name` at field 10 with its warning comment.
+- `src/gcmon/exporters/perfetto_builders.py` builds each sub-message field-by-field.
+- Wire-level regression tests: `tests/exporters/test_perfetto_builders.py` asserts raw
+  field numbers and wire types rather than round-tripping, and
+  `tests/exporters/test_perfetto_proto.py` reads the numbers back out of the `perfetto`
+  package's generated descriptors rather than trusting gcmon's own.

--- a/docs/adr/0002-perfetto-track-uuid-and-hierarchy.md
+++ b/docs/adr/0002-perfetto-track-uuid-and-hierarchy.md
@@ -26,11 +26,10 @@ pushed the thread down below its own counters.
 
 ## Decision
 
-**UUIDs are allocated sequentially from a per-trace counter starting at 1**
-(`PerfettoTrackState._alloc_uuid`), lazily, on first use of each track. The state object
-maps identity (`pid`, `(pid, iid)`, `(pid, iid, name, metric)`) to the allocated UUID, so
-the same track reuses its UUID across flushes. Collision-freedom comes from the counter,
-not from bit arithmetic.
+**UUIDs are allocated sequentially from a per-trace counter starting at 1**, lazily, on
+first use of each track. The state object maps identity (`pid`, `(pid, iid)`,
+`(pid, iid, name, metric)`) to the allocated UUID, so the same track reuses its UUID
+across flushes. Collision-freedom comes from the counter, not from bit arithmetic.
 
 **`uuid = 0` is reserved.** It is Perfetto's special root descriptor, used to carry
 `process_ordering` / `thread_ordering` hints. It is not a parent, and nothing may point
@@ -74,14 +73,15 @@ with it.
 
 ## Implementation
 
-- `src/gcmon/exporters/perfetto_track_state.py`, `PerfettoTrackState._next_uuid` seeded to
-  `1` and `_alloc_uuid`.
-- `:234`, `:239`, `get_process_track_uuid` and `get_thread_track_uuid` (lazy, memoized).
-- `:79-83`, `ProcessDescriptorField` (`PID = 1`, `CMDLINE = 2`, `PROCESS_NAME = 6`,
-  `START_TIMESTAMP_NS = 7`); the sub-message itself is written at `TrackDescriptor` field 3.
-- `:705-725`, `_emit_thread_descriptor`: `parent_uuid` = process track,
-  `sibling_order_rank = 0`, no `child_ordering`.
-- `:324`, `build_track_descriptor`, which omits `parent_uuid` when it is `None`.
+- `src/gcmon/exporters/perfetto_track_state.py` holds the counter, seeded to `1`, and the
+  lazy memoized lookups that hand out the process and thread track UUIDs.
+- `src/gcmon/exporters/perfetto_proto.py` carries the `ProcessDescriptor` field numbers
+  (`PID = 1`, `CMDLINE = 2`, `PROCESS_NAME = 6`, `START_TIMESTAMP_NS = 7`); the
+  sub-message itself is written at `TrackDescriptor` field 3.
+- `src/gcmon/exporters/perfetto_format.py` emits the thread descriptor with `parent_uuid`
+  set to the process track, `sibling_order_rank = 0` and no `child_ordering`.
+- `src/gcmon/exporters/perfetto_builders.py` omits `parent_uuid` from the wire when it is
+  `None`.
 - Tests: `tests/exporters/test_perfetto_track_state.py` for uuid allocation,
   `tests/exporters/test_perfetto_format.py` for the emitted hierarchy,
   `tests/exporters/test_perfetto_exporter_integration.py` (the trace-processor `track`

--- a/docs/adr/0003-gc-metrics-group-track.md
+++ b/docs/adr/0003-gc-metrics-group-track.md
@@ -36,9 +36,9 @@ Insert an intermediate **non-OS-scoped grouping track named `GC Metrics`**, one 
 
 Because the group is a plain custom track, the trace processor honors `child_ordering` on
 it and `sibling_order_rank` on its children. Counter rows now carry a non-NULL `parent_id`
-pointing at the `GC Metrics` row, and `_COUNTER_RANKS` takes effect *inside* the group.
+pointing at the `GC Metrics` row, and the ranking takes effect *inside* the group.
 
-Ranks come from `_COUNTER_RANKS`, a single ordered table covering each metric.
+Ranks come from a single ordered table covering each metric.
 `heap_size` and `rss` come first (they are top-level, see
 [ADR-0004](0004-toplevel-shared-counters.md)), then `collected`, `uncollectable` (emitted
 only when non-zero), `candidates`, `duration`, and the rest. Inserting a metric
@@ -55,8 +55,8 @@ shifts the ranks below it, which is fine: only the relative order matters.
   this and accepted it, since ordering within the group still works.
 - The group is collapsible, which keeps the top-level track list short. That is why
   [ADR-0004](0004-toplevel-shared-counters.md) keeps `heap_size` *outside* the group.
-- Any new per-generation metric inherits the grouping for free; only membership in
-  `_TOPLEVEL_COUNTER_METRICS` opts a metric out.
+- Any new per-generation metric inherits the grouping for free; only the top-level metrics
+  of [ADR-0004](0004-toplevel-shared-counters.md) sit outside it.
 
 ## Alternatives considered
 
@@ -72,13 +72,10 @@ shifts the ranks below it, which is fine: only the relative order matters.
 
 ## Implementation
 
-- `src/gcmon/exporters/perfetto_format.py`, `_COUNTER_GROUP_NAME = "GC Metrics"`.
-- `:728-752`, `_emit_counter_group_descriptor`, emitted once per `(pid, iid)`, with the
-  docstring recording *why* the group is a plain custom track.
-- `:150-162`, `_COUNTER_RANKS`.
-- `:790-802`, the grouped counter branch, parenting to the group UUID.
-- Tests: `tests/exporters/test_perfetto_format.py`
-  (`test_counter_tracks_parented_to_counter_group`);
+- `src/gcmon/exporters/perfetto_format.py` names the group track, emits its descriptor
+  once per `(pid, iid)` with a docstring recording *why* the group is a plain custom
+  track, holds the rank table, and parents each per-generation counter to the group UUID.
+- Tests: `tests/exporters/test_perfetto_format.py` covers the parenting;
   `tests/exporters/test_perfetto_exporter_integration.py` asserts the counter rows'
   `parent_id` is non-NULL and equals the group row, the assertion that would have caught
   the original bug.

--- a/docs/adr/0004-toplevel-shared-counters.md
+++ b/docs/adr/0004-toplevel-shared-counters.md
@@ -22,21 +22,21 @@ Naming is a second constraint on any fix. The encoder names a counter track
 
 ## Decision
 
-**`heap_size` is emitted as its own counter event**, separate from the per-generation one:
-`counter_event(pid, tid, "heap_size", ts_start_ns, {"heap_size": ...})`. It is removed from
-the per-generation `counter_data` payload, which now carries only `collected`, `candidates`,
+**`heap_size` is emitted as its own counter event**, named `heap_size` and carrying a
+single arg of the same name, separate from the per-generation one. It is removed from the
+per-generation counter payload, which now carries only `collected`, `candidates`,
 `duration`, and `uncollectable` (the last only when non-zero). All generations on a
 `(pid, tid)` feed the same single `heap_size` track; latest value wins on the time axis,
 which is the correct semantics for a process-wide gauge.
 
-**Single-argument counter events use the metric as the display name.** When
-`len(event.args) == 1`, the Perfetto track name is the metric alone (`heap_size`, not
-`heap_size heap_size`); the Chrome encoder blanks the event name for the same reason,
+**Single-argument counter events use the metric as the display name.** When a counter
+event carries exactly one arg, the Perfetto track name is the metric alone (`heap_size`,
+not `heap_size heap_size`); the Chrome encoder blanks the event name for the same reason,
 since Chrome's trace processor derives the track name as `f"{event_name} {arg_key}"`.
 
-**`_TOPLEVEL_COUNTER_METRICS = frozenset({"heap_size", "rss"})` is the single switch.**
-Metrics in this set are parented directly to the process track, outside the collapsible
-`GC Metrics` group. Adding a metric to the set moves it out of the group.
+**One set of metric names is the switch**, holding `heap_size` and `rss`. Metrics in it
+are parented directly to the process track, outside the collapsible `GC Metrics` group.
+Adding a metric to the set moves it out of the group.
 
 `heap_size` stays on the `GC Pause(N)` slice's args as well, so it remains queryable
 per-pause from the slice `args` table.
@@ -47,14 +47,14 @@ per-pause from the slice `args` table.
 - **Accepted trade-off:** because these tracks are parented to the OS-scoped process
   track, the trace processor drops their `sibling_order_rank` (the rule from
   [ADR-0003](0003-gc-metrics-group-track.md)). Their position is a UI heuristic; in the
-  Perfetto UI they render *below* the `GC Metrics` group. `_COUNTER_RANKS["heap_size"]`
-  is retained for documentation and forward-compatibility but is not honored.
-- **Chrome-consumer break:** `convert_item_to_trace_format` now emits two `C` events per
-  item rather than one. Downstream Chrome-trace tooling that assumed a single counter event
-  per GC pause, and read every metric from it, must read the consolidated event separately.
-  No consumer in this repository made that assumption.
-- New process-level metrics need only be added to `_TOPLEVEL_COUNTER_METRICS`; the naming
-  and parenting fall out.
+  Perfetto UI they render *below* the `GC Metrics` group. A rank for `heap_size` is
+  retained for documentation and forward-compatibility but is not honored.
+- **Chrome-consumer break:** the converter now emits two `C` events per item rather than
+  one. Downstream Chrome-trace tooling that assumed a single counter event per GC pause,
+  and read every metric from it, must read the consolidated event separately. No consumer
+  in this repository made that assumption.
+- New process-level metrics need only be added to the top-level set; the naming and
+  parenting fall out.
 
 ## Alternatives considered
 
@@ -73,15 +73,13 @@ per-pause from the slice `args` table.
 
 ## Implementation
 
-- `src/gcmon/exporters/trace_converter.py:50-56`, per-generation `counter_data`, without
-  `heap_size`.
-- `:281-289`, the separate consolidated `heap_size` counter event.
-- `src/gcmon/exporters/perfetto_format.py`, `_TOPLEVEL_COUNTER_METRICS`.
-- `:775-787`, the top-level branch, parenting directly to the process track.
-- `src/gcmon/exporters/encoder.py`, where `JsonEventEncoder` blanks the name of single-arg
-  counter events so Chrome does not derive a doubled track name.
-- Tests: `tests/exporters/test_chrome_trace_format.py:359-384`
-  (`test_heap_size_counter_event_is_shared_across_generations`, asserting
-  `"heap_size" not in` the per-generation args);
+- `src/gcmon/exporters/trace_converter.py` builds the per-generation counter payload
+  without `heap_size`, and emits the consolidated `heap_size` event beside it.
+- `src/gcmon/exporters/perfetto_format.py` holds the top-level metric set and parents
+  those tracks directly to the process track.
+- `src/gcmon/exporters/encoder.py` blanks the name of single-arg counter events in the
+  Chrome encoder, so Chrome does not derive a doubled track name.
+- Tests: `tests/exporters/test_chrome_trace_format.py` asserts `heap_size` is absent from
+  the per-generation args and shared across generations;
   `tests/exporters/test_perfetto_exporter_integration.py` asserts exactly one `heap_size`
   track and zero `G{N} heap_size` tracks.

--- a/docs/adr/0005-counter-y-axis-share-key.md
+++ b/docs/adr/0005-counter-y-axis-share-key.md
@@ -25,17 +25,18 @@ half of the requirement holds and sharing is scoped to a single process.
 `G2 collected` all get `y_axis_share_key = "collected"`; the per-generation `candidates`,
 `duration` and `uncollectable` tracks get their own metric names.
 
-There is **no lookup table**, on purpose. The grouped-counter emission path passes
-`y_axis_share_key=metric`, so any metric added to the counter payload in future gets
-correct Y-axis sharing with no code change. This is the whole point of keying on the name.
+There is **no lookup table**, on purpose. The grouped-counter emission path sets
+`y_axis_share_key` to the metric name it already has, so any metric added to the counter
+payload in future gets correct Y-axis sharing with no code change. This is the whole point
+of keying on the name.
 
 Two normalizations guard the edges:
 
-- `y_axis_share_key=""` is treated as `None`: no field is emitted, and the
+- An empty share key is treated as an absent one: no field is emitted, and the
   `CounterDescriptor` stays the empty submessage. This defends against silently disabling
   sharing for a future metric with an empty name.
-- A non-counter track (`is_counter=False`) ignores any share key passed to it; field 8 is
-  not emitted at all.
+- A track that is not a counter ignores any share key passed to it; field 8 is not emitted
+  at all.
 
 When a share key is set, the `CounterDescriptor` submessage contains **only** field 7. No
 other `CounterDescriptor` field (`type`, `categories`, `unit`, `unit_multiplier`,
@@ -61,30 +62,31 @@ minimal.
   Perfetto version surfaces it, with no test edit. The wire-level tests are the source of
   truth.
 - Per [ADR-0001](0001-hand-rolled-perfetto-protobuf-encoder.md), the `CounterDescriptor`
-  submessage is hand-encoded via a local `CounterDescriptorField` enum. Do not reach for
-  the generated class from the `perfetto` package.
+  submessage is hand-encoded against a local field-number enum. Do not reach for the
+  generated class from the `perfetto` package.
 
 ## Alternatives considered
 
-- **A `_Y_AXIS_SHARE_KEYS` dict mapping metric to key.** Rejected: it duplicates
-  the metric name and needs an edit whenever someone adds a metric. Forget the edit and
-  that metric silently loses its shared axis.
+- **A lookup table mapping metric to share key.** Rejected: it duplicates the metric name
+  and needs an edit whenever someone adds a metric. Forget the edit and that metric
+  silently loses its shared axis.
 - **A share key on `heap_size` / `rss` for forward-compatibility.** Rejected: no peers, so
   it is bytes on the wire that do nothing.
-- **Setting `unit` / `unit_name` at the same time.** Deferred to a separate change;
-  `test_only_share_key_field_is_set_no_other_counter_fields` locks the current minimal
-  submessage so the scope creep would be caught.
+- **Setting `unit` / `unit_name` at the same time.** Deferred to a separate change; a
+  wire-level test locks the current minimal submessage, so the scope creep would be
+  caught.
 
 ## Implementation
 
-- `src/gcmon/exporters/perfetto_proto.py`, `CounterDescriptorField.Y_AXIS_SHARE_KEY = 7`.
-- `src/gcmon/exporters/perfetto_builders.py`, the emit logic in `build_track_descriptor`:
-  populated submessage when the key is truthy, empty submessage otherwise, nothing at all
-  when `is_counter=False`.
-- `src/gcmon/exporters/perfetto_format.py`, `_emit_counter_track_descriptor`, which passes
-  `y_axis_share_key=metric` on the grouped branch and omits it on the top-level branch.
-- Tests: `tests/exporters/test_perfetto_builders.py`, `test_y_axis_share_key_emitted_at_field_8`
-  and its neighbours (empty-submessage fallback, non-counter ignore, empty-string
-  normalization, only-field-7 guard); `tests/exporters/test_perfetto_counter_tracks.py` for
-  the same values as reached through a convert pass;
-  `tests/exporters/test_perfetto_exporter_integration.py:547-595` (the `xfail`'d SQL pair).
+- `src/gcmon/exporters/perfetto_proto.py` carries `y_axis_share_key` as field 7 of
+  `CounterDescriptor`.
+- `src/gcmon/exporters/perfetto_builders.py` decides what reaches the wire: a populated
+  submessage when the key is truthy, an empty one otherwise, and nothing at all for a
+  track that is not a counter.
+- `src/gcmon/exporters/perfetto_format.py` passes the metric name as the share key on the
+  grouped branch and omits it on the top-level branch.
+- Tests: `tests/exporters/test_perfetto_builders.py` covers field 8 at the wire level
+  (empty-submessage fallback, non-counter ignore, empty-string normalization,
+  only-field-7 guard); `tests/exporters/test_perfetto_counter_tracks.py` checks the same
+  values as reached through a convert pass;
+  `tests/exporters/test_perfetto_exporter_integration.py` holds the `xfail`'d SQL pair.

--- a/docs/adr/0006-begin-end-slice-pairs.md
+++ b/docs/adr/0006-begin-end-slice-pairs.md
@@ -24,10 +24,9 @@ sides disagreed on the shape of a span.
 
 The Chrome backend emits begin/end pairs. `ph: "X"` is not produced.
 
-- The `PauseEvent` / `IncrementalEvent` types and their `pause_event()` / `inc_event()`
-  factories are replaced by `BeginEvent` / `EndEvent` and `begin_event()` / `end_event()`.
-- `convert_item_to_trace_format` emits a begin/end pair per span rather than a single
-  complete event.
+- The event model's span types and their factories are begin/end pairs; the complete-event
+  types they replaced are gone.
+- The converter emits a begin/end pair per span rather than a single complete event.
 - The Chrome trace reader parses `ph: "B"` and `ph: "E"`; `ph: "X"` parsing is removed.
 - Timestamp normalization covers `"B"`, `"E"`, `"C"` and `"I"` events.
 
@@ -45,8 +44,8 @@ carrying independent metadata at each end is not derivable from a complete event
   so nothing downstream had to change.
 - A truncated or interrupted Chrome trace can end with an unmatched `"B"`. Both viewers
   tolerate this; a complete event could never be half-written.
-- The Chrome converter no longer calls `dur_to_us`. Duration is a property of the pair,
-  not of a record.
+- The Chrome converter no longer converts a duration to microseconds. Duration is a
+  property of the pair, not of a record.
 
 ## Alternatives considered
 
@@ -58,9 +57,8 @@ carrying independent metadata at each end is not derivable from a complete event
 
 ## Implementation
 
-- `src/gcmon/trace_event.py`, `BeginEvent` / `EndEvent` and the `begin_event()` /
-  `end_event()` factories.
-- `src/gcmon/exporters/trace_converter.py`, which emits the pairs.
-- `src/gcmon/exporters/chrome_trace_io.py`, where `_parse_events` handles `"B"` / `"E"`
-  and `_normalize_trace_timestamps` collects `"B"`, `"E"`, `"C"`, `"I"`.
-- `tests/helpers.py`, `assert_is_begin` / `assert_is_end`.
+- `src/gcmon/trace_event.py` holds the begin and end event types and their factories.
+- `src/gcmon/exporters/trace_converter.py` emits the pairs.
+- `src/gcmon/exporters/chrome_trace_io.py` parses `"B"` / `"E"` on the way in, and
+  normalizes timestamps across `"B"`, `"E"`, `"C"` and `"I"`.
+- `tests/helpers.py` carries the begin/end assertions the suites share.

--- a/docs/adr/0007-shared-trace-converter-pipeline.md
+++ b/docs/adr/0007-shared-trace-converter-pipeline.md
@@ -21,16 +21,14 @@ begin/end pair, nothing structural stood in the way of sharing the conversion.
 ## Decision
 
 A single pipeline `TGCStatsInfo → list[TraceEvent]` lives in
-`src/gcmon/exporters/trace_converter.py` (`convert_item_to_trace_format`,
-`convert_to_trace_format`). It owns the only copy of the sub-phase logic and the naming
-strings.
+`src/gcmon/exporters/trace_converter.py`. It owns the only copy of the sub-phase logic and
+the naming strings.
 
-`TraceEvent`, the union of `BeginEvent`, `EndEvent`, `InstantEvent`, `CounterEvent`,
-`ProcessMeta` and `ThreadMeta` in `src/gcmon/trace_event.py`, is the contract between the
-converter and the backends. Each backend consumes that list and does nothing but encode:
-Chrome to JSON, Perfetto to protobuf via `convert_trace_events_to_perfetto`. Neither
-inspects `TGCStatsInfo` fields any more. `PerfettoTrackState` remains for track UUID
-management, and cmdline handling is untouched.
+`TraceEvent`, the union of the begin, end, instant and counter events plus `ProcessMeta`
+and `ThreadMeta` in `src/gcmon/trace_event.py`, is the contract between the converter and
+the backends. Each backend consumes that list and does nothing but encode: Chrome to JSON,
+Perfetto to protobuf. Neither inspects `TGCStatsInfo` fields any more. Track UUID
+management stays where it was, and cmdline handling is untouched.
 
 The refactor also settled two behaviours:
 
@@ -41,14 +39,14 @@ carried one. Descriptors are now time-independent across the board. Consumers mu
 on a descriptor timestamp.
 
 **Invalid-timestamp filtering moved to the producer.** The `ts_start < ts_stop` guard now
-lives in `EventsMonitor.poll`, not in the Perfetto converter. This is an intentional
+lives in the monitor's poll, not in the Perfetto converter. This is an intentional
 behaviour change for the Chrome backend, which previously emitted zero-duration events for
 such records and now drops them the way Perfetto always did. Filtering at the producer is
 exporter-agnostic and keeps the shared converter pure: filter once, emit everywhere.
 
 **`ProcessMeta` precedes `ThreadMeta`** for a given pid. This is part of the public
-contract of the event stream. `convert_trace_events_to_perfetto` synthesizes a process
-descriptor defensively if a `ThreadMeta` arrives first, but callers should not rely on that.
+contract of the event stream. The Perfetto conversion synthesizes a process descriptor
+defensively if a `ThreadMeta` arrives first, but callers should not rely on that.
 
 ## Consequences
 
@@ -58,12 +56,12 @@ descriptor defensively if a `ThreadMeta` arrives first, but callers should not r
   described in [ADR-0012](0012-trace-output-formats.md).
 - `chrome_trace_format.py` became a thin re-export module so existing importers keep working.
 - Records with `ts_start >= ts_stop` no longer reach any exporter. If you are debugging
-  "an event I expected is missing from the Chrome trace", `EventsMonitor.poll` is where it
+  "an event I expected is missing from the Chrome trace", the monitor's poll is where it
   was dropped.
 - Adding an output format means writing an encoder, not a converter.
   [ADR-0008](0008-buffered-exporter-and-encoder-protocol.md) builds on that.
-- `LossMsg` is emitted from `_ingest`, so one converter branch carries it to every exporter.
-  See [ADR-0015](0015-gc-loss-spans-on-their-own-track.md).
+- `LossMsg` is emitted from the same poll, so one converter branch carries it to every
+  exporter. See [ADR-0015](0015-gc-loss-spans-on-their-own-track.md).
 
 ## Alternatives considered
 
@@ -79,13 +77,12 @@ descriptor defensively if a `ThreadMeta` arrives first, but callers should not r
 
 ## Implementation
 
-- `src/gcmon/exporters/trace_converter.py:33`, `convert_item_to_trace_format`; `:294`,
-  `convert_to_trace_format`.
-- `src/gcmon/trace_event.py`, the `TraceEvent` union and factories.
-- `src/gcmon/exporters/perfetto_format.py`, `convert_trace_events_to_perfetto`.
-  `_emit_counter_track_descriptor` returns `(uuid, bytes)` so the call site does not look
-  the UUID up twice.
-- `src/gcmon/monitor.py`, `_ingest`'s per-`(pid, iid, gen)` `collections` cursor and the
-  `ts_start < ts_stop` validity guard in `_is_complete`.
-- Tests: `test_poll_skips_invalid_timestamp_event`, `test_poll_skips_equal_timestamp_event`,
-  `test_invalid_timestamps_produces_events`, `test_equal_timestamps_produces_events`.
+- `src/gcmon/exporters/trace_converter.py` converts one record, and a whole batch, to
+  `TraceEvent`s.
+- `src/gcmon/trace_event.py` holds the `TraceEvent` union and its factories.
+- `src/gcmon/exporters/perfetto_format.py` encodes those events, emitting a counter track's
+  descriptor and its UUID together so the call site does not look the UUID up twice.
+- `src/gcmon/monitor.py` keeps the per-`(pid, iid, gen)` `collections` cursor and applies
+  the `ts_start < ts_stop` validity guard before anything reaches the converter.
+- Tests: `tests/monitoring/test_monitor.py` covers the records the poll drops, and
+  `tests/exporters/test_perfetto_format.py` the events that survive to conversion.

--- a/docs/adr/0008-buffered-exporter-and-encoder-protocol.md
+++ b/docs/adr/0008-buffered-exporter-and-encoder-protocol.md
@@ -22,8 +22,8 @@ a duplicate process descriptor in the output.
 ## Decision
 
 **`BufferedTraceExporter`** (`_buffered_exporter.py`) owns the lifecycle: the two locks,
-the buffer and flush threshold, `add_event` / `add_instant_event` / `close`, and
-`_build_meta(pid, iid)`.
+the buffer and flush threshold, `add_event` / `add_instant_event` / `close`, and building
+a pid's meta events.
 
 **`EventEncoder`** (a `Protocol` in `encoder.py`) owns format-specific byte production
 through three methods: `open(path)`, `write_events(events)`, `close()`. Two implementations
@@ -31,24 +31,23 @@ exist: `JsonEventEncoder` for Chrome Trace Event JSON and `ProtobufEventEncoder`
 Perfetto binary.
 
 `TraceExporter` and `PerfettoExporter` become thin subclasses that construct the right
-encoder in `__init__`. Their public constructor signatures are unchanged.
+encoder. Their public constructor signatures are unchanged.
 
-**`_build_meta` is atomic.** The check and the emit happen inside a single critical
+**Meta building is atomic.** The check and the emit happen inside a single critical
 section under the state lock, closing the race. This is the property the two previous
 implementations were reaching for and missing.
 
 The split settled three further questions:
 
-- **`_seen_pids` lives in the base, not the encoder.** The base's `_build_meta` is the
-  single source of truth for "have we seen this pid/iid?". The encoder can therefore rely
-  on exactly one `ProcessMeta` per pid arriving, which means its `_ensure_cmdline` runs at
-  most once per pid, and the previous double-checked-locking dance around cmdline
-  registration is gone.
-- **`_ensure_cmdline` runs under the I/O lock.** The old design ran the slow
+- **The seen-pid set lives in the base, not the encoder.** The base is the single source
+  of truth for "have we seen this pid/iid?". The encoder can therefore rely on exactly one
+  `ProcessMeta` per pid arriving, which means it registers a cmdline at most once per pid,
+  and the previous double-checked-locking dance around that registration is gone.
+- **Cmdline registration runs under the I/O lock.** The old design ran the slow
   `psutil.Process(pid).cmdline()` call outside any lock to avoid serializing threads. It
   now runs inside `write_events`, which the base serializes. Accepted: the cost is paid at
   most once per pid, because of the point above.
-- **`JsonEventEncoder.close()` writes `[]\n` only if nothing was ever written.** If any
+- **`JsonEventEncoder` writes `[]\n` on close only if nothing was ever written.** If any
   `write_events` succeeded it writes `\n]\n` instead. Both paths produce a valid JSON array.
 
 ## Consequences
@@ -59,32 +58,33 @@ The split settled three further questions:
   dependency on the base class.
 - Output bytes were unchanged by the refactor, verified by the existing structural tests,
   which decode the output and assert on each meaningful field.
-- `close()` is idempotent (guarded by `_closed`).
-- **`add_event` after `close()` silently drops the event.** The base does not check
-  `_closed` on the add path. This matches the pre-refactor behaviour, and the alternative
-  is raising from a monitoring callback during shutdown.
+- `close()` is idempotent, guarded by a closed flag.
+- **`add_event` after `close()` silently drops the event.** The base does not check that
+  flag on the add path. This matches the pre-refactor behaviour, and the alternative is
+  raising from a monitoring callback during shutdown.
 - `flush_threshold <= 0` means "always flush": the first event triggers a write.
 - The encoder catches a cmdline provider failure, logs a warning, and emits the descriptor
   without a cmdline. A `psutil` error never costs you the trace.
 
 ## Alternatives considered
 
-- **A common base class with abstract `_encode` methods instead of a separate protocol
+- **A common base class with abstract encode methods instead of a separate protocol
   object.** Rejected: composition lets the encoder run without an exporter, which is what
   `combine` needs.
-- **Keep `_ensure_cmdline` outside the lock.** Rejected: it required the double-checked
-  locking that the atomic `_build_meta` makes unnecessary, and the call now happens
-  once per pid, so the serialization is not worth the complexity.
+- **Keep cmdline registration outside the lock.** Rejected: it required the double-checked
+  locking that atomic meta building makes unnecessary, and the call now happens once per
+  pid, so the serialization is not worth the complexity.
 - **Fold `JsonlExporter` / `StdoutExporter` into the same base.** Not done: they consume
   raw `TGCStatsInfo`, not `TraceEvent`, so the data shapes differ. This remains open work.
 
 ## Implementation
 
-- `src/gcmon/exporters/_buffered_exporter.py:53-64`, `_build_meta`, with the check-and-emit
-  inside `with self._lock:` at `:57`.
-- `src/gcmon/exporters/encoder.py:41`, the `EventEncoder` Protocol; `:54`,
-  `JsonEventEncoder`; `:95`, `ProtobufEventEncoder`; `:126`, `_ensure_cmdline`.
-- Tests: `tests/exporters/test_exporter_thread_safety.py:593` (`TestMetaDedupRaceClosed`,
-  firing two threads at a brand-new pid); the structural tests in
-  `tests/exporters/test_chrome_trace_exporter.py` and `tests/exporters/test_perfetto_exporter.py`;
-  the stress suite run at `--count 20`.
+- `src/gcmon/exporters/_buffered_exporter.py` builds a pid's meta events with the
+  check-and-emit inside one critical section under the state lock.
+- `src/gcmon/exporters/encoder.py` declares the `EventEncoder` protocol, both
+  implementations, and the cmdline registration each one runs.
+- Tests: `tests/exporters/test_exporter_thread_safety.py` fires two threads at a brand-new
+  pid to pin the dedup race; the structural tests in
+  `tests/exporters/test_chrome_trace_exporter.py` and
+  `tests/exporters/test_perfetto_exporter.py` decode the output; the stress suite runs at
+  `--count 20`.

--- a/docs/adr/0009-nanoseconds-canonical-time-unit.md
+++ b/docs/adr/0009-nanoseconds-canonical-time-unit.md
@@ -7,7 +7,7 @@
 
 `TGCStatsInfo` records timestamps in nanoseconds, reading them from `time.time_ns()`,
 which is Python's canonical clock unit. The `TraceEvent` model stored microseconds, so the
-converter called `ts_to_us()` on each timestamp field on the way in.
+converter divided each timestamp field down on the way in.
 
 That was fine while Chrome was the only backend: the Chrome Trace Event format is specified
 in microseconds, so the model matched the output.
@@ -23,9 +23,8 @@ question is where the conversion belongs.
 
 ## Decision
 
-`TraceEvent.ts` is nanoseconds. The four factories (`begin_event`, `end_event`,
-`instant_event`, `counter_event`) take `ts_ns` and assign it verbatim. The converter no
-longer calls `ts_to_us`; `TGCStatsInfo` values flow through unchanged.
+`TraceEvent.ts` is nanoseconds. The four event factories take `ts_ns` and assign it
+verbatim. The converter no longer divides; `TGCStatsInfo` values flow through unchanged.
 
 **Conversion happens at the encoder, once, per format:**
 
@@ -50,8 +49,8 @@ looking at bytes on disk.
 - When reading tests, watch the boundary: in-memory assertions are in nanoseconds,
   assertions against decoded JSON are in microseconds. The same literal means different
   things on either side of `JsonEventEncoder`.
-- `write_trace_events` was deleted; `combine_files` uses `JsonEventEncoder` so there is
-  exactly one code path that knows about the ns→µs division.
+- The standalone trace-writing helper was deleted; `combine` goes through
+  `JsonEventEncoder` too, so exactly one code path knows about the ns→µs division.
 
 ## Alternatives considered
 
@@ -65,13 +64,12 @@ looking at bytes on disk.
 
 ## Implementation
 
-- `src/gcmon/trace_event.py:102,114-119,131-134,145`, the four factories taking `ts_ns`.
-- `src/gcmon/data.py:53-55`, `ts_to_us`, now called only by the JSON encoder.
-- `src/gcmon/exporters/encoder.py:72-74`, the ns→µs conversion in
-  `JsonEventEncoder.write_events`.
-- `src/gcmon/exporters/perfetto_format.py`, `convert_trace_events_to_perfetto`, where every
-  branch passes `event.ts` straight to `timestamp=`.
-- Tests: `tests/test_time.py:5-12`;
-  `tests/exporters/test_chrome_trace_format.py:183`
-  (`test_preserves_timestamps_in_nanoseconds`);
-  the direct duration comparison in `tests/test_convert_cmd_perfetto.py`.
+- `src/gcmon/trace_event.py` holds the four factories, each taking `ts_ns`.
+- `src/gcmon/data.py` holds the ns→µs conversion, now called only by the JSON encoder.
+- `src/gcmon/exporters/encoder.py` applies it as it serializes Chrome output.
+- `src/gcmon/exporters/perfetto_format.py` passes `event.ts` straight to the packet
+  timestamp on every branch.
+- Tests: `tests/test_time.py` for the conversion itself;
+  `tests/exporters/test_chrome_trace_format.py` for timestamps preserved in nanoseconds
+  through the model; the direct duration comparison in
+  `tests/test_convert_cmd_perfetto.py`.

--- a/docs/adr/0010-process-identity-cmdline-and-start-marker.md
+++ b/docs/adr/0010-process-identity-cmdline-and-start-marker.md
@@ -53,7 +53,7 @@ cmdline. No exception escapes, and the trace stays valid.
 
 The exporter collects cmdline for the main pid and each child, and emits it on the first
 `TrackDescriptor` for each. [ADR-0008](0008-buffered-exporter-and-encoder-protocol.md)'s
-atomic `_build_meta` guarantees that happens exactly once.
+atomic meta building guarantees that happens exactly once.
 
 ## Consequences
 
@@ -91,15 +91,14 @@ atomic `_build_meta` guarantees that happens exactly once.
 
 ## Implementation
 
-- `src/gcmon/exporters/perfetto_proto.py`, `ProcessDescriptorField`
-  (`PID = 1`, `CMDLINE = 2`, `PROCESS_NAME = 6`); `TrackDescriptorField.DESCRIPTION = 14`.
-- `src/gcmon/exporters/perfetto_format.py`, `_START_PROCESS_INSTANT_NAME = "Start Process"`,
-  emitted by `_emit_start_process_marker` and driven by `_maybe_emit_start_process_marker`.
-- `src/gcmon/exporters/perfetto_process_lifetime.py`,
-  `_emit_process_lifetime_slice`, which puts the cmdline on the `Processes` slice's BEGIN
-  alongside the `real_start_ts` / `real_end_ts` annotations
+- `src/gcmon/exporters/perfetto_proto.py` carries the `ProcessDescriptor` field numbers
+  (`PID = 1`, `CMDLINE = 2`, `PROCESS_NAME = 6`) and `TrackDescriptor.description` at
+  field 14.
+- `src/gcmon/exporters/perfetto_format.py` names the `Start Process` marker and emits it at
+  most once per pid.
+- `src/gcmon/exporters/perfetto_process_lifetime.py` puts the cmdline on the `Processes`
+  slice's BEGIN alongside the `real_start_ts` / `real_end_ts` annotations
   ([ADR-0011](0011-process-lifetime-and-ordering.md)).
-- `src/gcmon/exporters/encoder.py:113`, the lazy `import psutil` in
-  `_default_cmdline_provider`; `:126`, `_ensure_cmdline`.
-- `src/gcmon/exporters/perfetto_track_state.py`, `PerfettoTrackState.set_cmdline` /
-  `get_cmdline`.
+- `src/gcmon/exporters/encoder.py` holds the default provider, with its lazy
+  `import psutil`, and registers each pid's cmdline once.
+- `src/gcmon/exporters/perfetto_track_state.py` stores a pid's cmdline and hands it back.

--- a/docs/adr/0011-process-lifetime-and-ordering.md
+++ b/docs/adr/0011-process-lifetime-and-ordering.md
@@ -54,8 +54,8 @@ nothing else: no name, no parent, no sub-message.
 **Process tracks are ranked by first event timestamp**, ties broken by ascending pid,
 sequential from 0. Only pids with at least one non-meta event get a rank.
 
-**The whole track is emitted at encoder close**, via `finalize_perfetto_packets`, called once
-from `ProtobufEventEncoder.close()`; convert passes record spans and emit nothing. Two
+**The whole track is emitted at encoder close**, once per trace; convert passes record
+spans and emit nothing. Two
 reasons the BEGIN cannot go out earlier: keeping the track laminar needs every pid's span in
 hand at once, and a clip discovered at close cannot correct a BEGIN already written. Nor
 could the END, since `BufferedTraceExporter` flushes in chunks of `flush_threshold`
@@ -78,14 +78,14 @@ because gcmon names every END and the trace processor matches it to the BEGIN wi
 rather than to the top of the stack, so an END cannot close the wrong slice. It does
 force-close anything sitting *above* the slice it matched, and that is what makes the other
 two collisions matter. Each is owned by one function and neither is optional: building the
-pair BEGIN-first is `_emit_process_lifetime_slice`'s job, because a zero-length span emitted
-END-first reads as `dur = -1`; putting the outer BEGIN of two spans sharing a start ahead of
-the inner is the sweep's, because `[(100, 2, 6), (101, 2, 3)]` emitted inner-first gives pid
-100 a duration of 1 instead of 4 plus a `misplaced_end_event`. Neither claim is argued: the
-fuzz suite below checks both against the trace processor. The sweep's sort is therefore
-load-bearing twice over — longer-first on a tie keeps the clip safe *and* orders these BEGINs —
-which is why `_clip_spans_to_laminar` sorts its own input rather than documenting the order as
-a precondition.
+pair BEGIN-first belongs to the emission site, because a zero-length span emitted END-first
+reads as `dur = -1`; putting the outer BEGIN of two spans sharing a start ahead of the
+inner belongs to the sweep, because `[(100, 2, 6), (101, 2, 3)]` emitted inner-first gives
+pid 100 a duration of 1 instead of 4 plus a `misplaced_end_event`. Neither claim is argued:
+the fuzz suite below checks both against the trace processor. The sweep's sort is therefore
+load-bearing twice over — longer-first on a tie keeps the clip safe *and* orders these
+BEGINs — which is why the sweep sorts its own input rather than documenting the order as a
+precondition.
 
 The sweep and the emission order together, on the crossing shape from the Context plus a nested
 third process (in ns, so the clip lands on 199):
@@ -130,10 +130,10 @@ nothing, both still get a BEGIN/END pair; the trace processor accepts it and rep
 observation is any non-meta trace event, counters included, or a **liveness observation** from
 `MonitorLoop`: a `(pid, ts)` pair meaning gcmon read GC state out of that process at that
 instant. `MonitorLoop` reports the whole `PollStatus.OK` set once per tick through
-`EventsExporter.add_process_liveness(pids, ts_ns)`, so the cost is one call per tick and not
-one per pid. `update_process_lifetime(pid, ts)` is a plain min/max with no keyword: the
-counter carve-out this ADR called provisional is **removed**, since the sampler liveness it
-kept out of the end is now reported directly.
+`add_process_liveness(pids, ts_ns)`, so the cost is one call per tick and not one per pid.
+The accumulator folds a `(pid, ts)` in as a plain min/max with no keyword: the counter
+carve-out this ADR called provisional is **removed**, since the sampler liveness it kept
+out of the end is now reported directly.
 
 **Liveness folds in alongside events rather than replacing them.** `[first OK, last OK]` was
 rejected because `get_gc_stats` returns collections that *already happened*, so a freshly
@@ -163,11 +163,11 @@ ship two definitions of a `Processes` slice.
 three methods meaning "translate a batch of `TraceEvent` into bytes"; a liveness observation
 is neither. `PerfettoExporter` builds its own `ProtobufEventEncoder`, so it keeps a typed
 handle and overrides `add_process_liveness`; Chrome, JSONL and stdout reach the
-`EventsExporter` no-op. The override takes `_io_lock`, which is not optional: it guards every
-other encoder touch including `close()`, and `ControlServer` writes from its own thread.
-Without it a concurrent read-modify-write can drop a min/max update, and a new pid arriving
-mid-`close()` can raise `RuntimeError: dictionary changed size during iteration` out of
-`get_process_lifetimes`.
+`EventsExporter` no-op. The override takes the I/O lock, which is not optional: it guards
+every other encoder touch including `close()`, and `ControlServer` writes from its own
+thread. Without it a concurrent read-modify-write can drop a min/max update, and a new pid
+arriving mid-`close()` can raise `RuntimeError: dictionary changed size during iteration`
+out of the span iteration.
 
 ## Consequences
 
@@ -178,8 +178,8 @@ mid-`close()` can raise `RuntimeError: dictionary changed size during iteration`
   is to `later.start - 1`. Siblings fanning out from a fork loop start microseconds apart, so
   the losses are severe in ordinary use: 1000 children with nanosecond start jitter and
   varying lifetimes retain **0.37%** of their total observed duration. `--rss` makes it
-  likelier still, since `RssSampler.tick` samples every live pid in one loop and counters
-  move a span's start. Liveness cuts the other way for part of a fan-out: children whose
+  likelier still, since the sampler reads every live pid in one loop and counters move a
+  span's start. Liveness cuts the other way for part of a fan-out: children whose
   earliest evidence is the tick that first polled them share that timestamp exactly and nest
   rather than clip, while those whose first GC event predates the poll keep their jitter.
 - **Which sibling gets sacrificed is not meaningful.** Within an RSS round the sample order is
@@ -190,18 +190,18 @@ mid-`close()` can raise `RuntimeError: dictionary changed size during iteration`
   `docs/perfetto-sql.md` carries the query.
 - **Exactly one slice per pid gcmon polled**, so consumers may join `Processes` slices to pids
   one-to-one. A pid that answered a single poll and never collected gets one; only a pid seen
-  through meta events alone has none. `finalize_perfetto_packets` therefore does *not* filter
-  on `has_pid`, which would have required a process descriptor and so an event.
-- **A zero-GC pid's slice carries no cmdline**, since `_ensure_cmdline` hangs off
+  through meta events alone has none. Finalization therefore does *not* filter on a pid
+  having a process descriptor, which would have required an event.
+- **A zero-GC pid's slice carries no cmdline**, since cmdline registration hangs off
   `write_events` and such a pid never reaches it. It has no process track either, which the UI
   hides anyway, the problem
   [ADR-0010](0010-process-identity-cmdline-and-start-marker.md)'s `Start Process` marker was
   invented for. Emitting either for it is out of scope.
-- **Rank gaps.** A zero-GC pid consumes a rank, since `get_process_track_ranks` sorts the dict
-  liveness writes, but has no descriptor to apply it to, so real pids get 0, 1, 2, 4, 5.
-  Harmless: `sibling_order_rank` is a sort key, not an index. Splitting the accumulator to
-  keep ranks event-derived would add a second exception to `update_process_lifetime` in the
-  change that deletes the first, for a cosmetic gain.
+- **Rank gaps.** A zero-GC pid consumes a rank, since ranking sorts the same dict liveness
+  writes, but has no descriptor to apply it to, so real pids get 0, 1, 2, 4, 5. Harmless:
+  `sibling_order_rank` is a sort key, not an index. Splitting the accumulator to keep ranks
+  event-derived would add a second exception to it in the change that deletes the first,
+  for a cosmetic gain.
 - **Deep nesting is now the normal shape.** Processes still alive when the loop stops share an
   end timestamp, and the sweep breaks out on `outer_end >= end`, so co-terminating spans nest
   one level per process instead of clipping. Staggered deaths still clip, so traces mix both.
@@ -220,12 +220,11 @@ mid-`close()` can raise `RuntimeError: dictionary changed size during iteration`
   the UI may still rearrange tracks in special contexts.
 - **Ranks are not applied retroactively.** If a pid's `ProcessMeta` lands in an earlier batch
   than its first non-meta event, the descriptor goes out before the rank is known, and
-  emission is idempotent, so that pid gets no rank. Within a batch the pre-pass in
-  `convert_trace_events_to_perfetto` folds every non-meta event into the span state *before*
-  the main loop, so same-batch `ProcessMeta` still gets its rank. Liveness shrinks this
-  without closing it: `monitor.poll` enqueues the `ProcessMeta` *during* the poll while the
-  liveness call happens after it, so a batch crossing `flush_threshold` mid-poll still emits a
-  rank-less descriptor.
+  emission is idempotent, so that pid gets no rank. Within a batch the Perfetto conversion's
+  pre-pass folds every non-meta event into the span state *before* the main loop, so
+  same-batch `ProcessMeta` still gets its rank. Liveness shrinks this without closing it: the
+  monitor enqueues the `ProcessMeta` *during* the poll while the liveness call happens after
+  it, so a batch crossing `flush_threshold` mid-poll still emits a rank-less descriptor.
 - The `Processes` block lands at the end of the file, descriptor first. The trace processor
   resolves track references across the whole trace rather than in file order.
 - Consumers enumerating slices must filter `track.name == 'Processes'`, as the equivalence
@@ -283,64 +282,54 @@ mid-`close()` can raise `RuntimeError: dictionary changed size during iteration`
 
 ## Implementation
 
-- `src/gcmon/exporters/perfetto_process_lifetime.py` holds this decision:
-  `_PROCESS_LIFETIME_TRACK_NAME = "Processes"`, the two `_emit_process_lifetime_*`
-  functions, `_record_process_lifetime`, `_clip_spans_to_laminar` and
-  `finalize_perfetto_packets`.
-- `src/gcmon/exporters/perfetto_proto.py`, `TrackDescriptorField.PROCESS_ORDERING = 19` and
-  `THREAD_ORDERING = 20`. Fields 6 and 7 on the same message are `chrome_process` and
-  `chrome_thread`, so a wrong number writes a different message and fails silently
+- `src/gcmon/exporters/perfetto_process_lifetime.py` holds this decision: the `Processes`
+  track name, the sweep, the two emission steps and the finalization the encoder calls at
+  close. The sweep sorts its input by `(start, -end, pid)` and returns it in that order,
+  carrying each span's observed start and end through untouched alongside the drawn ones,
+  so the emission site can annotate every slice without knowing which fields moved. The
+  track descriptor asserts on the once-per-trace flag rather than trusting its caller: a
+  second descriptor for one uuid is accepted silently, so nothing downstream would report
+  it.
+- `src/gcmon/exporters/perfetto_proto.py` carries `process_ordering` at field 19 and
+  `thread_ordering` at field 20. Fields 6 and 7 on the same message are `chrome_process`
+  and `chrome_thread`, so a wrong number writes a different message and fails silently
   ([ADR-0001](0001-hand-rolled-perfetto-protobuf-encoder.md)).
-- `src/gcmon/exporters/perfetto_track_state.py`,
-  `PerfettoTrackState.update_process_lifetime`, the span accumulator; a plain min/max taking
-  `(pid, ts)`, with no `extends_end` keyword since the carve-out was removed. Start and end
-  therefore always carry identical key sets. `get_process_lifetimes` is a plain accessor; the
-  once-per-trace contract is a `_process_lifetime_emitted` flag that
-  `finalize_perfetto_packets` checks and sets, which is what makes it safe to call twice and
-  covers the non-idempotent track descriptor too. `get_process_track_ranks` sorts by
-  `(start_ts, pid)`.
-- `_emit_process_lifetime_track_descriptor` asserts on that flag rather than trusting its
-  caller: a second descriptor for one uuid is accepted silently, so nothing downstream would
-  report it.
-- `_clip_spans_to_laminar`, the stack sweep, sorts its input by `(start, -end, pid)` and
-  returns in that order. It also carries each span's observed start and end through untouched
-  alongside the drawn ones, so the emission site can annotate every slice without knowing
-  which fields the sweep may have moved.
-- `src/gcmon/exporters/perfetto_format.py`, `_emit_root_descriptor`, guarded by
-  `has_root_descriptor`.
+- `src/gcmon/exporters/perfetto_track_state.py` holds the span accumulator, a plain min/max
+  over `(pid, ts)` with no keyword since the carve-out was removed, so start and end always
+  carry identical key sets. It hands the spans back for finalization, ranks them by
+  `(start_ts, pid)`, and owns the once-per-trace flag that makes finalization safe to call
+  twice, covering the non-idempotent track descriptor too.
+- `src/gcmon/exporters/perfetto_format.py` emits the root descriptor, guarded so it goes
+  out once.
 - The liveness path, loop to accumulator: `src/gcmon/monitor_loop.py` takes one
-  `time.monotonic_ns()` per tick, calls
-  `self._monitor.exporter.add_process_liveness(live_pids, now_ns)` after the poll phase
-  (skipped on an empty set), and passes `now_ns / 1e9` to `RssSampler.tick`.
+  `time.monotonic_ns()` per tick, reports the live set to the exporter after the poll phase
+  (skipped on an empty set), and passes the same instant in seconds to the RSS sampler.
   `src/gcmon/exporters/exporter.py` holds the no-op base;
   `src/gcmon/exporters/combined_exporter.py` fans it out;
-  `src/gcmon/exporters/perfetto_exporter.py` overrides it under `_io_lock`, forwarding to
-  `ProtobufEventEncoder.record_process_liveness` in `src/gcmon/exporters/encoder.py`.
-- `ProtobufEventEncoder.close()` gates on having packets to emit, not on `_has_written`. That
-  guard meant "no spans exist" while only events could create one; liveness reaches
-  `_track_state` without passing through `write_events`, so the first write may now have to
-  select `"wb"`. A trace with neither events nor liveness still produces no file.
-- `tests/exporters/test_perfetto_process_lifetime.py`: `TestClipSpansToLaminar` covers the
-  sweep directly at full statement and branch coverage; `TestProcessLifetimeLaminarClipping`
-  covers the same shapes through `finalize_perfetto_packets` and additionally checks the
-  emitted BEGIN/ENDs are ones the trace processor can pair up.
-  `TestProcessLifetimeState` for the accumulator is in
-  `tests/exporters/test_perfetto_track_state.py`, next to the class it exercises. Ranking and
-  `start_timestamp_ns` are in `tests/exporters/test_perfetto_ordering.py`.
+  `src/gcmon/exporters/perfetto_exporter.py` overrides it under the I/O lock, forwarding to
+  `src/gcmon/exporters/encoder.py`.
+- Encoder close gates on having packets to emit, not on whether anything was written
+  before. That guard meant "no spans exist" while only events could create one; liveness
+  reaches the track state without passing through `write_events`, so the first write may
+  now have to select `"wb"`. A trace with neither events nor liveness still produces no
+  file.
+- `tests/exporters/test_perfetto_process_lifetime.py` covers the sweep directly at full
+  statement and branch coverage, and the same shapes through finalization, additionally
+  checking the emitted BEGIN/ENDs are ones the trace processor can pair up. The accumulator
+  is covered in `tests/exporters/test_perfetto_track_state.py`, next to the class it
+  exercises. Ranking and `start_timestamp_ns` are in
+  `tests/exporters/test_perfetto_ordering.py`.
 - `tests/exporters/test_perfetto_emission_order_fuzz.py`, marked `fuzz` and run by its own CI
   job, settles the emission-order claims above against the real trace processor: paired
   emission reads back exactly over random laminar span sets, and the orderings rejected here
   are asserted to *break*, so the positive case cannot pass by ordering being irrelevant. It
   also pins both sides of the 512-deep nesting limit above.
-- `tests/exporters/test_perfetto_exporter_integration.py`: `TestCrossingProcessSpans` asserts
-  `misplaced_end_event == 0` against a deliberately crossing trace,
-  `TestZeroDurationProcessSpans` that a same-ts BEGIN/END is paired rather than orphaned and
-  that every pid keeps a slice, `TestMonitorReportedLiveness` and `TestLivenessOnlyTrace` the
-  liveness shapes, and `TestMultiFlushProcessesTrack::test_slice_end_is_last_event_ts`, which
-  forces many flushes with `flush_threshold=5` and asserts
-  `slice.ts + slice.dur == last_event_ts`.
-- Liveness unit tests: `tests/monitoring/test_monitor_loop.py::TestProcessLiveness`;
-  `tests/exporters/test_perfetto_exporter.py::TestProcessLivenessRoundTrip`, whose `_io_lock`
-  test asserts by contention rather than by inspection; and
-  `tests/exporters/test_buffered_exporter.py::TestAddProcessLivenessIsPerfettoOnly`, pinning
+- `tests/exporters/test_perfetto_exporter_integration.py` asserts
+  `misplaced_end_event == 0` against a deliberately crossing trace, that a same-ts
+  BEGIN/END is paired rather than orphaned and every pid keeps a slice, the two liveness
+  shapes, and that a run forced through many flushes with `flush_threshold=5` still ends
+  its slice at the last event's timestamp.
+- Liveness unit tests: `tests/monitoring/test_monitor_loop.py`;
+  `tests/exporters/test_perfetto_exporter.py`, whose locking test asserts by contention
+  rather than by inspection; and `tests/exporters/test_buffered_exporter.py`, pinning
   Chrome, JSONL and stdout output as byte-identical with and without liveness.

--- a/docs/adr/0012-trace-output-formats.md
+++ b/docs/adr/0012-trace-output-formats.md
@@ -55,8 +55,7 @@ verbatim.
 state. `close()` closes Chrome inside a `try` and Perfetto in the `finally`, so a Chrome
 failure still closes Perfetto.
 
-`derive_combined_paths(base)` turns one `-o` argument into two files using
-`Path.stem`, which strips only the last extension:
+One `-o` argument becomes two files via `Path.stem`, which strips only the last extension:
 
 | `-o` | chrome | perfetto |
 |---|---|---|
@@ -102,21 +101,21 @@ included. Its whitelist had omitted both, so `GCMON_FORMAT=perfetto` fell back t
   `-o` and writes one file.
 - **Auto-deriving the output extension from `--output-format` in `combine`.** Rejected:
   you control `-o`, and rewriting a path you typed would surprise you.
-- **A custom `cmdline_provider` for `combine`.** Rejected: the default degrades gracefully,
+- **A custom cmdline provider for `combine`.** Rejected: the default degrades gracefully,
   and historical pids have no cmdline to find.
 
 ## Implementation
 
-- `src/gcmon/commands/convert_cmd.py:65-70`, `--output-format` choices; `:90-95`, the
+- `src/gcmon/commands/convert_cmd.py` holds the `--output-format` choices and the
   `chrome → jsonl` rejection.
-- `src/gcmon/exporters/chrome_trace_io.py:169-230`, `combine_files`, with the `jsonl → jsonl`
-  fast path at `:182`, per-file normalization in the load loop, and the `perfetto` branch at
-  `:222-228`.
-- `src/gcmon/exporters/combined_exporter.py:14`, `derive_combined_paths`; `:36`,
-  `CombinedTraceExporter`.
-- `src/gcmon/exporters/exporter_factory.py:27-31`, the `chrome+perfetto` case.
-- `src/gcmon/_env.py:135`, the `get_env_format` whitelist.
-- Tests: `tests/test_convert_cmd_perfetto.py` (609 lines, trace-processor driven; the
-  chrome↔perfetto content-equivalence class at `:465`);
-  `tests/exporters/test_combined_exporter.py` and `test_combined_exporter_integration.py`;
-  `tests/monitoring/test_monitor_cmd.py:208-267` (end-to-end, both files written).
+- `src/gcmon/exporters/chrome_trace_io.py` combines the inputs: the `jsonl → jsonl` fast
+  path, per-file normalization in the load loop, and the `perfetto` branch.
+- `src/gcmon/exporters/combined_exporter.py` derives the two paths and forwards to both
+  sub-exporters.
+- `src/gcmon/exporters/exporter_factory.py` handles the `chrome+perfetto` case.
+- `src/gcmon/_env.py` holds the `GCMON_FORMAT` whitelist.
+- Tests: `tests/test_convert_cmd_perfetto.py` is trace-processor driven and carries the
+  chrome↔perfetto content-equivalence assertions;
+  `tests/exporters/test_combined_exporter.py` and `test_combined_exporter_integration.py`
+  cover the forwarder; `tests/monitoring/test_monitor_cmd.py` checks end-to-end that both
+  files are written.

--- a/docs/adr/0013-rss-sampling.md
+++ b/docs/adr/0013-rss-sampling.md
@@ -38,7 +38,7 @@ timers, or how a sample turns into an event.
 `time.monotonic_ns()` per tick, passing the nanoseconds to `add_process_liveness` and
 `now_ns / 1e9` here.
 
-**The sampler callback is injectable**, the same pattern as `cmdline_provider` in
+**The sampler callback is injectable**, the same pattern as the cmdline provider in
 `ProtobufEventEncoder`. Tests pass a mock and never touch `psutil`. The constructor checks
 availability **once**: if the import fails, it disables the sampler, logs at info level,
 and `tick()` becomes a no-op. No per-sample import guard.
@@ -47,11 +47,11 @@ and `tick()` becomes a no-op. No per-sample import guard.
 live set is cleared each iteration, so a pid must pass a fresh poll to be sampled. No
 stale pids, and a process that dies between the poll and the RSS read yields nothing.
 
-**The RSS counter uses a sentinel `tid = -1`.** `_build_meta` gates thread-meta emission on
+**The RSS counter uses a sentinel `tid = -1`.** Meta building gates thread-meta emission on
 `iid >= 0`, so the `ProcessMeta` goes out once, deduped as usual, and **no phantom
 `ThreadMeta` is created**. The counter track key is `(pid, -1, "rss", "rss")`.
 
-`"rss"` is in `_TOPLEVEL_COUNTER_METRICS`, so the track is parented directly to the process
+`"rss"` is one of the top-level metrics, so the track is parented directly to the process
 track, outside the `GC Metrics` group, with the display name `rss`
 ([ADR-0004](0004-toplevel-shared-counters.md)).
 
@@ -66,13 +66,13 @@ the 0.1 s GC poll rate.
 - You can unit-test `RssSampler` without `psutil` and without a monitor loop.
 - Missing `psutil`, a dead process, or a permission error each produce no sample and no
   error. `--rss` on a machine without `psutil` is ignored, with one info log.
-- **Perfetto-only in practice.** The base `EventsExporter.add_rss_sample` is a no-op and
-  `BufferedTraceExporter` overrides it, so JSONL and stdout carry no RSS. Chrome traces
+- **Perfetto-only in practice.** `add_rss_sample` is a no-op on the `EventsExporter` base
+  and `BufferedTraceExporter` overrides it, so JSONL and stdout carry no RSS. Chrome traces
   *technically* contain the counter event, since it flows through the same buffered base
   into `JsonEventEncoder`, but that is a side effect of the shared base. Nobody validates
   or tests it. Only the Perfetto path is a supported feature.
-- Adding `"rss"` to `_TOPLEVEL_COUNTER_METRICS` brings the accepted trade-off
-  from ADR-0004 with it: its `sibling_order_rank` is dropped because its parent is OS-scoped.
+- Adding `"rss"` to the top-level set brings the accepted trade-off from ADR-0004 with it:
+  its `sibling_order_rank` is dropped because its parent is OS-scoped.
 - The counter payload key is `"rss"` (`{"rss": rss_bytes}`). The event carries a
   single argument, so the display name normalizes to the metric name and the key never
   surfaces in the UI.
@@ -80,7 +80,7 @@ the 0.1 s GC poll rate.
 ## Alternatives considered
 
 - **`tid = 0` for the process-level counter.** Rejected: `0` is a legitimate interpreter id,
-  so it can collide with a real thread, and `_build_meta` would manufacture a
+  so it can collide with a real thread, and meta building would manufacture a
   `ThreadMeta(pid, 0, "Thread 0")` that describes nothing. A negative sentinel cannot
   collide, and one comparison guards it.
 - **Sampling inside `MonitorLoop` at the GC poll rate.** Rejected on cost and coupling:
@@ -88,19 +88,19 @@ the 0.1 s GC poll rate.
   core loop.
 - **Making RSS always-on.** Rejected: it requires `psutil` and adds syscalls to each run,
   for a metric most people do not need.
-- **A guard-and-import inside `_sample`.** Rejected: the availability answer cannot change
+- **A guard-and-import at each sample.** Rejected: the availability answer cannot change
   during a run, so checking once at construction is cheaper and clearer.
 
 ## Implementation
 
-- `src/gcmon/rss_sampler.py:14`, `RssSampler`; `:54`, `tick(now, live_pids)`; `:64`,
-  `_sample`; `:79`, `_default_rss_sampler`, catching `NoSuchProcess` / `AccessDenied`.
-- `src/gcmon/exporters/_buffered_exporter.py:18`, `_RSS_TID = -1`; `:61`, the `iid >= 0`
-  guard in `_build_meta`; `:77-82`, `add_rss_sample`.
-- `src/gcmon/exporters/perfetto_format.py`, `"rss"` in `_TOPLEVEL_COUNTER_METRICS`.
-- `src/gcmon/monitor_loop.py`, live-pid collection, then liveness, then `tick`;
-  `src/gcmon/commands/monitoring_base.py:58`, construction.
-- `src/gcmon/_env.py:209,221`, `get_env_rss` and `get_env_rss_interval`.
+- `src/gcmon/rss_sampler.py` holds `RssSampler`, its `tick(now, live_pids)` entry point,
+  the interval check, and the default sampler catching `NoSuchProcess` / `AccessDenied`.
+- `src/gcmon/exporters/_buffered_exporter.py` holds the `-1` sentinel, the `iid >= 0` guard
+  that suppresses thread meta for it, and `add_rss_sample`.
+- `src/gcmon/exporters/perfetto_format.py` carries `"rss"` in the top-level metric set.
+- `src/gcmon/monitor_loop.py` collects live pids, reports liveness, then ticks the sampler;
+  `src/gcmon/commands/monitoring_base.py` constructs it.
+- `src/gcmon/_env.py` reads `GCMON_RSS` and `GCMON_RSS_INTERVAL`.
 - Tests: `tests/test_rss_sampler.py` (interval timing, live-pid filtering, injected sampler,
   psutil-unavailable fallback); `tests/exporters/test_buffered_exporter.py` (`iid = -1`
   emits no `ThreadMeta`); `tests/benchmarks/test_rss_sampler_bench.py` (read latency).

--- a/docs/adr/0014-perfetto-integration-test-strategy.md
+++ b/docs/adr/0014-perfetto-integration-test-strategy.md
@@ -1,4 +1,4 @@
-# ADR-0014: Validate traces against the real trace processor; gate only stress and benchmarks
+# ADR-0014: Validate traces against the real trace processor; deselect slow suites by marker
 
 - **Status:** Accepted
 - **Date:** 2026-06-12 (stress marker) / 2026-06-18 (trace-processor tests) / 2026-08-02
@@ -17,8 +17,8 @@ Only the trace processor can settle whether a trace means what you think it mean
 the same binary the Perfetto UI runs in the browser.
 
 Separately, `ControlClient` is the child-side IPC surface used by each monitored process.
-Its `_send()` and `close()` paths are locked, and the *server* side had a thread-safety
-class, but the client side had no regression guard.
+Its send and `close()` paths are locked, and the *server* side had a thread-safety suite,
+but the client side had no regression guard.
 
 ## Decision
 
@@ -109,16 +109,17 @@ tests do not assert on it.
 
 ## Implementation
 
-- `pyproject.toml:54`, `perfetto` in `[tool.poetry.group.dev.dependencies]`; `:99-103`, the
-  `stress`, `benchmark` and `fuzz` marker registrations; `:104`, the `addopts` deselection.
+- `pyproject.toml` holds `perfetto` in `[tool.poetry.group.dev.dependencies]`, the `stress`,
+  `benchmark` and `fuzz` marker registrations, and the `addopts` deselection.
 - `.github/workflows/ci.yml`, the always-on `test` job, plus the separate `stress-test` and
   `fuzz-test` jobs.
 - `tests/exporters/test_perfetto_emission_order_fuzz.py`, the only `fuzz`-marked file: it
   pins ADR-0011's emission-order claims, positive case and negative control both.
-- `tests/exporters/test_perfetto_exporter_integration.py`, the `trace_processor` fixture,
-  the `_write_trace` helper, and the chrome/perfetto parametrization.
+- `tests/exporters/test_perfetto_exporter_integration.py` holds the trace-processor fixture,
+  the trace-writing helper, and the chrome/perfetto parametrization.
 - `tests/test_convert_cmd_perfetto.py`, the same approach applied to the `combine` paths,
   including the chrome↔perfetto content-equivalence test.
-- `tests/control/test_control_client_thread_safety.py`, `TestConcurrentSend` and
-  `TestSendCloseRace`, both marked `stress`.
-- `tests/exporters/test_exporter_thread_safety.py:593`, `TestMetaDedupRaceClosed`.
+- `tests/control/test_control_client_thread_safety.py` covers concurrent sends and the
+  send/close race, both marked `stress`.
+- `tests/exporters/test_exporter_thread_safety.py` covers the meta-dedup race from
+  [ADR-0008](0008-buffered-exporter-and-encoder-protocol.md).

--- a/src/gcmon/exporters/perfetto_proto.py
+++ b/src/gcmon/exporters/perfetto_proto.py
@@ -99,6 +99,9 @@ class TrackEventField(IntEnum):
 
 
 class DebugAnnotationField(IntEnum):
+    # Not 1. Upstream moved the name string to 10 and left field 1 holding a
+    # ``uint64`` interned ID in the same oneof, so a string written at 1 is
+    # dropped or read as a garbage IID. Do not "fix" this back (ADR-0001).
     NAME = 10
     BOOL_VALUE = 2
     INT_VALUE = 4

--- a/src/gcmon/exporters/perfetto_proto.py
+++ b/src/gcmon/exporters/perfetto_proto.py
@@ -99,9 +99,6 @@ class TrackEventField(IntEnum):
 
 
 class DebugAnnotationField(IntEnum):
-    # Not 1. Upstream moved the name string to 10 and left field 1 holding a
-    # ``uint64`` interned ID in the same oneof, so a string written at 1 is
-    # dropped or read as a garbage IID. Do not "fix" this back (ADR-0001).
     NAME = 10
     BOOL_VALUE = 2
     INT_VALUE = 4

--- a/src/gcmon/rss_sampler.py
+++ b/src/gcmon/rss_sampler.py
@@ -1,4 +1,8 @@
-"""RSS (Resident Set Size) sampling for monitored processes."""
+"""RSS (Resident Set Size) sampling for monitored processes.
+
+Why sampling lives in a class of its own, on a sentinel track, behind a flag:
+ADR-0013. The loop drives it once per tick, after reporting liveness (ADR-0011).
+"""
 
 import logging
 import time


### PR DESCRIPTION
Every record now anchors by module path and by the names outside the module boundary