### PR TITLE
Add specs 0035-0043 from the src/gcmon structure review

### DIFF
--- a/specs/0029-jsonl-and-stdout-duplicate-the-buffering.md
+++ b/specs/0029-jsonl-and-stdout-duplicate-the-buffering.md
@@ -1,10 +1,23 @@
 # 0029 — Share one buffer-and-flush implementation with the JSONL exporters
 
-- **Status:** Not started
+- **Status:** **Superseded** by [0036](0036-one-exporter-method-per-record-kind.md), which
+  removes the duplication by construction rather than by extraction
 - **Kind:** feature — cleanup
 - **Effort:** M
 - **Origin:** post-v0.2.0 code review (old spec 18, REQ-3 and REQ-4)
 - **Respects:** [ADR-0008](../docs/adr/0008-buffered-exporter-and-encoder-protocol.md) (exporter buffers, encoder serializes), [ADR-0009](../docs/adr/0009-nanoseconds-canonical-time-unit.md) (nanoseconds internally)
+
+## 0. Why this is superseded
+
+The three byte-identical buffering blocks exist because `EventsExporter` has three `add_*`
+methods for the JSONL path to implement. 0036 collapses the interface to one `add`, so there is
+one block and nothing left to extract — §4's generic holder is not needed under that design.
+
+Everything else here still holds and 0036 carries it forward verbatim: the JSONL schema does not
+change and JSONL does not move onto `TraceEvent` (§4, and the rejected alternative that goes
+with it), the missing `_closed` guard, the `_open_writer` override, and the golden-file test.
+Read §4 before touching the JSONL exporter — it is the fullest statement of why the file format
+is load-bearing, and 0036 summarizes rather than replaces it.
 
 ## 1. Problem statement
 

--- a/specs/0035-derive-every-gc-sub-phase-from-one-table.md
+++ b/specs/0035-derive-every-gc-sub-phase-from-one-table.md
@@ -1,0 +1,189 @@
+# 0035 — Derive every GC sub-phase from one table
+
+- **Status:** Not started
+- **Kind:** feature — cleanup
+- **Effort:** L
+- **Origin:** code structure review of `src/gcmon`, 2026-08-15
+- **Respects:** [ADR-0007](../docs/adr/0007-shared-trace-converter-pipeline.md) (one conversion
+  pipeline — this extends its decision rather than changing it),
+  [ADR-0009](../docs/adr/0009-nanoseconds-canonical-time-unit.md) (nanoseconds internally)
+
+## 1. Problem statement
+
+Nothing an operator sees is wrong today. This is the largest single maintenance cost in the
+codebase: CPython's collector has eight optional sub-phases, and gcmon writes that list out by
+hand in six separate places. Adding the ninth means editing all six, in six different shapes,
+and nothing fails if one is missed — the sub-phase simply does not appear in that output. A
+miss in the converter costs a slice in the trace; a miss in the stats table costs a `--stats`
+row; a miss in the normalizer leaves one timestamp unshifted in a `combine --normalize` run,
+which reads as a slice at the wrong place on the timeline rather than as an error.
+
+ADR-0007 already made this argument once, for the two trace backends, and won it. The same
+duplication survives across the other three consumers.
+
+## 2. Solution
+
+For an operator, nothing changes: the same slices, the same `--stats` rows, the same JSONL
+fields, byte for byte. What changes is that a maintainer adding a sub-phase writes one row in
+one table, and every consumer picks it up — or a test tells them the row is wrong before it
+reaches a trace.
+
+## 3. User stories
+
+1. As a maintainer tracking a new CPython GC sub-phase, I want to declare it once, so that a
+   trace, a `--stats` table and a JSONL line cannot disagree about whether gcmon supports it.
+2. As a maintainer, I want a misspelled field name to fail a test rather than silently produce
+   a sub-phase that never appears, so that the failure arrives in CI and not in a capture.
+3. As a maintainer reading `trace_converter`, I want the eight near-identical begin/end blocks
+   to be one loop, so that the one block that differs is visible instead of buried.
+4. As an operator comparing `--stats` against a Perfetto trace of the same run, I want the two
+   to cover exactly the same set of sub-phases, so that a row missing from one is a real
+   finding and not a gap in gcmon.
+5. As an operator running `gcmon combine --normalize` over JSONL, I want every timestamp on a
+   record shifted, so that no sub-phase slice lands at an absolute timestamp beside rebased
+   siblings.
+6. As a gcmon maintainer reviewing a sub-phase patch, I want the diff to be one table row plus
+   its test, so that review is about whether the phase is right rather than whether six edits
+   match.
+7. As someone reading the codebase for the first time, I want one place that answers "what
+   sub-phases does gcmon know about", so that I do not have to reconcile six partial lists.
+8. As a maintainer, I want the conversion benchmark to hold, so that collapsing the cascades
+   does not quietly make a large capture slower to convert.
+
+## 4. Implementation decisions
+
+**The six sites.** Each holds its own copy of the sub-phase list, in its own shape:
+
+| Site | Shape today |
+|---|---|
+| `data.GCStatsInfo` | the optional timestamp and count fields |
+| `protocol` | eight per-phase `Protocol` classes and nine `has_*` TypeGuards |
+| `protocol.to_mapping` | seven `if has_*(item):` blocks assigning field by field |
+| `stats.METRICS` | nine `Metric` classes, each a name and a two-field getter |
+| `trace_converter.convert_item_to_trace_format` | eight near-identical begin/end blocks |
+| `chrome_trace_io._normalize_jsonl_timestamps` | eight `if has_*(item):` subtraction blocks |
+
+`data.GCStatsInfo` stays as it is — it is the msgspec decode target and its fields are the
+JSONL schema, which is public and documented in
+[docs/formats.md](../docs/formats.md#jsonl-output). The table describes those fields; it does
+not replace them.
+
+**4.1 — One `Phase` table, in the model layer.** A tuple per sub-phase, ordered as the
+collector runs them. The shape, which is the decision:
+
+```python
+class Phase(NamedTuple):
+    key: str            # "mark_alive" — the METRICS key and the --stats row identity
+    label: str          # "Mark Alive" — slice name; "(gen)" is appended at the call site
+    category: str       # "gc.mark.alive"
+    present: str        # the field whose presence means the target reported this phase
+    start: str          # may name *another* phase's stop field
+    stop: str
+    args: tuple[str, ...] = ()          # record fields carried onto the slice's args
+    gens: frozenset[int] | None = None  # None means every generation
+```
+
+`present` is separate from `start` and that separation is the whole reason a naive table is
+wrong. Three phases begin at the preceding phase's stop: finalize-garbage starts at the
+handle-weakrefs stop, handle-resurrected at the finalize-garbage stop, clear-weakrefs at the
+handle-resurrected stop. `has_finalize_garbage` accordingly probes the *stop* field, not the
+start. A table that assumed `present == start` would ask whether the previous phase ran.
+
+`gens` carries the two generation restrictions the converter applies today — increment size is
+shown for generations under 2, alive size for generations over 0 — so they stop being inline
+conditions in the middle of a block.
+
+**4.2 — The `GC Pause` row is in the table.** It is not optional and it is not a sub-phase, but
+`stats.METRICS` already treats it as one and `stats_output` keys its exact-versus-estimated
+column off `metric_key == "pause"`. Keeping it in the table with `present` set to its start
+field preserves that, and the one caller that must distinguish it keeps doing so by key.
+
+**4.3 — The four consumers become walks over the table.** `to_mapping` walks it for the
+optional fields and keeps its explicit list of the mandatory ones. `stats.METRICS` is derived
+from it and the nine `Metric` classes go — each is a name and a two-field getter, which is
+what a row already is. `convert_item_to_trace_format` becomes a loop emitting a begin/end pair
+per present phase whose interval is non-empty, preserving today's `stop - start > 0` guard.
+`_normalize_jsonl_timestamps` walks the start and stop field names.
+
+**4.4 — The `has_*` guards and the per-phase `Protocol` classes go.** Once the table drives
+every consumer, nothing narrows to `TMarkAliveInfo` or its siblings; a single
+`phase_present(item, phase)` replaces nine guards. `is_gc_stats`, `is_instant`, `is_loss` and
+`has_pause_ts` stay — they discriminate *record kinds*, which is a different job and one the
+loss work relies on.
+
+**Accepted cost: the cascades are statically checked and a table indexed by field-name strings
+is not.** This is the strongest objection to the spec and it is real. mypy and pyrefly verify
+today that `item.ts_mark_alive_start` exists on the type the guard narrowed to; `getattr(item,
+phase.start)` verifies nothing. The mitigation is the same one [0030](0030-exporter-hygiene-batch.md)
+§4.1 chose for `_COUNTER_RANKS`: a test that asserts every field name in every row exists on
+`data.GCStatsInfo`, checked by name. That converts a typo from a silently absent sub-phase into
+a test failure, which is a better outcome than today's — where a *missing* row is not caught by
+anything at all.
+
+**Rejected: generate the table from `GCStatsInfo` by field-name convention** (pair anything
+matching `ts_<name>_start` with `ts_<name>_stop`). Four of the eight phases do not follow the
+convention, including all three that begin at a predecessor's stop, so the generator would need
+a table of exceptions — which is the table, plus a generator.
+
+**Rejected: keep the guards and share only the naming strings.** That is precisely what
+ADR-0007 rejected when it merged the two trace backends: "the guards were the small part."
+
+**Open, to settle when picked up:** whether `to_mapping` keeps its hand-written mandatory-field
+block or moves to `msgspec.to_builtins` with the optional fields omitted. It reads `TGCStatsInfo`,
+a `Protocol`, so the record may be a `_remote_debugging` object rather than a struct; whether
+`to_builtins` handles that is the fact that settles it. Out of scope either way — the JSONL
+bytes must not change.
+
+## 5. Seams and testing decisions
+
+- **Seam:** the chrome↔perfetto content-equivalence test in `tests/test_convert_cmd_perfetto.py`,
+  through the trace processor. It is the highest seam available: it observes the sub-phases as
+  *slices in a trace*, which is what the table exists to produce, rather than observing the
+  table. `tests/stats/test_metrics.py` and the JSONL golden file cover the two consumers the
+  trace processor cannot see.
+- **New seam needed:** none for behaviour. One new test *file* at an existing seam — the
+  table-completeness test in §4 — which asserts against `data.GCStatsInfo`, not against the
+  table itself.
+- **What makes a good test here:** assert the trace still *means* the same thing — that a
+  record carrying all eight sub-phases produces the same eight named slices, at the same
+  timestamps, on the same track. A test that reads the phase list out of the table and checks
+  the converter emitted that list proves only that the loop ran; it would pass with every row
+  wrong. Pin the expected slice names and categories as literals in the test, since they are
+  the public surface an operator queries in PerfettoSQL.
+- **Prior art:** `tests/exporters/test_perfetto_format.py` for per-slice assertions;
+  `tests/test_convert_cmd_perfetto.py` for the cross-encoder equivalence shape;
+  `tests/stats/test_metrics.py` for the METRICS coverage assertions.
+- **Cases:**
+  1. A record carrying every sub-phase produces the identical `TraceEvent` list before and
+     after — same order, same names, same categories, same args.
+  2. A record carrying none of them produces only the `GC Pause` pair and the counters.
+  3. The generation restrictions hold: increment size appears for gen 0 and 1 and not gen 2;
+     alive size for gen 1 and 2 and not gen 0.
+  4. Every field name in the table exists on `data.GCStatsInfo`.
+  5. Regression guard: byte-identical JSONL for a fixed record set, and
+     `tests/benchmarks/test_bench_trace_conversion.py` within its current budget — the
+     converter comments call the args dict the largest single cost of converting a record, so a
+     table-driven rewrite must not add a per-phase allocation.
+
+## 6. Out of scope
+
+- Any change to the JSONL schema or to slice names, categories and arg keys. All are public;
+  this is a refactor with no output diff.
+- The `--stats` table layout in `stats_output`. It consumes `METRICS`; it does not care where
+  `METRICS` came from.
+- Splitting `stats.py` and `data.py` into modules by concern — that is
+  [0039](0039-split-the-record-model-and-stats-by-concern.md), which this spec makes smaller
+  by deleting the nine `Metric` classes first.
+- The loss record's own fields. `GenLoss` and `LossMsg` are one shape each with no optional
+  variants ([ADR-0015](../docs/adr/0015-gc-loss-spans-on-their-own-track.md)); there is nothing
+  to tabulate.
+- Adding any sub-phase CPython does not report today.
+
+## 7. Further notes
+
+This extends ADR-0007 rather than contradicting it: that record decided a `TGCStatsInfo`
+becomes a `TraceEvent` in exactly one place, and it holds. What it did not reach was the three
+consumers that read the record for something other than a trace — the JSONL writer, the stats
+accumulator and the offline normalizer. When this lands, ADR-0007's Context and Consequences
+should be amended to say the sub-phase list has one home for *every* consumer, not only for the
+two backends.

--- a/specs/0036-one-exporter-method-per-record-kind.md
+++ b/specs/0036-one-exporter-method-per-record-kind.md
@@ -1,0 +1,184 @@
+# 0036 — Take every record kind through one exporter method
+
+- **Status:** Not started
+- **Kind:** feature — cleanup
+- **Effort:** M
+- **Origin:** code structure review of `src/gcmon`, 2026-08-15. **Supersedes**
+  [0029](0029-jsonl-and-stdout-duplicate-the-buffering.md), whose buffering duplication this
+  removes by construction; §4 carries forward every constraint 0029 established.
+- **Respects:** [ADR-0008](../docs/adr/0008-buffered-exporter-and-encoder-protocol.md)
+  (exporter buffers, encoder serializes), [ADR-0011](../docs/adr/0011-process-lifetime-and-ordering.md)
+  (liveness arrives batched, once per tick), [ADR-0013](../docs/adr/0013-rss-sampling.md)
+  (RSS on a sentinel track), [ADR-0015](../docs/adr/0015-gc-loss-spans-on-their-own-track.md)
+
+## 1. Problem statement
+
+An operator running `gcmon run -s app.py --format jsonl --rss` is told "RSS tracking is not
+supported for --format jsonl; RSS samples will be discarded." That warning is true, but it does
+not come from the exporter that discards them — it comes from `RSS_CAPABLE_FORMATS`, a tuple of
+format-name strings hand-maintained in the CLI layer, three modules away from the code whose
+capability it describes. Add an exporter and forget the tuple and the operator gets the wrong
+answer in one of two directions: a warning about a format that now works, or silence while
+their samples are dropped.
+
+Underneath it is the reason the tuple exists. `EventsExporter` has grown one method per record
+kind — GC record, instant, loss window, RSS sample, liveness — and three of the five are no-op
+implementations in the base class, each carrying a `# noqa: B027` to quiet the linter that
+objects to exactly this. Every new record kind widens the interface for every exporter, and an
+exporter opts out by inheriting a method that does nothing. Nothing about that is visible at
+the seam.
+
+## 2. Solution
+
+For an operator, output is byte-identical on every format, and the RSS warning says the same
+sentence — it just becomes true by construction, asked of the exporter that will or will not
+handle the samples. For a maintainer, adding a record kind means adding a branch to the
+exporters that care, and the ones that do not are unchanged rather than silently widened.
+
+## 3. User stories
+
+1. As an operator using `--format jsonl --rss`, I want the warning about discarded samples to
+   come from the exporter that discards them, so that it cannot be stale.
+2. As an operator using a format that gains RSS support later, I want the warning to stop
+   appearing without anyone remembering to edit a list, so that gcmon does not lie about its
+   own capabilities.
+3. As a maintainer adding a record kind, I want to add it to the exporters that handle it, so
+   that the interface does not grow a method every exporter must know to ignore.
+4. As a maintainer adding a record kind, I want the JSONL buffering written once, so that a
+   record type cannot end up flushed on one path and dropped on another. *(carried from 0029)*
+5. As an operator with an existing JSONL pipeline, I want the file format to stay exactly as it
+   is, so that my parsers and my archived captures keep working. *(carried from 0029)*
+6. As an operator running `gcmon combine` over JSONL I recorded last month, I want it to read
+   back unchanged, so that this is not a migration. *(carried from 0029)*
+7. As a maintainer, I want `close()` to mean closed on every exporter, so that a double-close
+   in a teardown path is not a per-class question. *(carried from 0029)*
+8. As someone piping `--format stdout` into a log aggregator, I want each line flushed as it is
+   today, so that a long-running monitor is not silent between flush thresholds. *(carried from 0029)*
+9. As a maintainer writing a test exporter, I want to implement two methods rather than six, so
+   that a fake stays cheap to write and cannot drift from the real interface.
+10. As a maintainer of `--format chrome+perfetto`, I want the fan-out exporter to forward one
+    call rather than one per record kind, so that a new kind cannot be forwarded to one
+    sub-exporter and not the other.
+
+## 4. Implementation decisions
+
+**4.1 — The interface becomes three methods, not one.** The obvious collapse is a single
+`add(pid, record)` over a tagged union, and it is wrong for liveness. `add_process_liveness`
+takes a *set* of pids and one timestamp, deliberately: ADR-0011 has the monitor report the
+whole live set once per tick, and `PerfettoExporter` takes `_io_lock` once for the batch. So:
+
+```python
+type ExportRecord = TGCStatsInfo | TInstantMsg | TLossMsg | RssSample
+
+class EventsExporter(ABC):
+    @abstractmethod
+    def add(self, pid: int, record: ExportRecord) -> None: ...
+    @abstractmethod
+    def close(self) -> None: ...
+
+    def add_process_liveness(self, pids: Set[int], ts_ns: int) -> None:  # noqa: B027
+        """Batched per ADR-0011. One no-op, and it is documented as one."""
+```
+
+Five methods become two plus one batched outlier, and the three `# noqa: B027` no-ops become
+one whose reason for existing is a decision rather than an omission.
+
+**Rejected: N per-pid calls for liveness.** It preserves a one-method interface and costs
+ADR-0011's batching — a lock acquisition per pid per tick instead of one.
+
+**Rejected: `add(record)` with every record carrying its own pid.** `TGCStatsInfo` may be a
+`_remote_debugging` object, which has no pid; the monitor supplies it. Making the exporter's
+unit an envelope means an allocation per record, and GC records outnumber every other kind by
+orders of magnitude.
+
+**4.2 — RSS becomes a record.** `add_rss_sample(pid, rss_bytes, ts_ns)` becomes an `RssSample`
+struct passed to `add`. The sentinel track and the counter it produces are unchanged
+(ADR-0013).
+
+**4.3 — Capability is asked of the exporter.** Each exporter declares the record kinds it
+handles; `EventsExporter.add`'s base behaviour for an unhandled kind stays what it is today —
+drop it, silently, because raising from a monitoring callback is the worse failure. The RSS
+warning moves out of `get_monitoring_options` and into `run_monitoring_loop`, where the
+exporter has been constructed and can answer for itself, and `RSS_CAPABLE_FORMATS` is deleted.
+The operator still sees the warning before monitoring starts; it moves a few lines later in the
+log, after the "Output:" / "Format:" preamble.
+
+**4.4 — The JSONL buffering collapses rather than being extracted.** This is why 0029 is
+superseded and not merely reordered: its three byte-identical lock/append/threshold/flush
+blocks exist *because* there are three `add_*` methods. One `add` means one block, with the
+record-shaping done by a `match` on the kind. 0029's extraction of a generic holder is no
+longer needed.
+
+**Carried from 0029, unchanged — the JSONL record shape does not change, and JSONL does not
+move onto `TraceEvent`.** `BufferedTraceExporter` buffers `TraceEvent`; `JsonlExporter` buffers
+`to_mapping(record)` — the raw record fields. Those are not two encodings of one thing. The
+JSONL schema is public, documented per-field in
+[docs/formats.md](../docs/formats.md#jsonl-output), and read back by `chrome_trace_io.read_jsonl`
+to drive `gcmon combine`. Routing JSONL through the `TraceEvent` model would rewrite every line
+of every JSONL file gcmon has produced and break the combine reader in the same commit.
+Rejected there, rejected here.
+
+**4.5 — `close()` gets a `_closed` guard on the JSONL path.** Carried from 0029:
+`JsonlExporter.close` has none, so unlike every other exporter it accepts records after close
+and buffers them where nothing will flush them. ADR-0008 already settled that a record after
+close is dropped silently; this makes JSONL agree.
+
+**4.6 — `StdoutExporter` keeps its `_open_writer` override.** Carried from 0029. Three lines,
+and the one thing that genuinely differs between a file and an already-open stream.
+
+**4.7 — `CombinedTraceExporter` shrinks to two forwarding methods plus liveness.** It is a
+fan-out and nothing else; a record kind can no longer be forwarded to one sub-exporter and
+missed on the other. Its private-attribute reach is [0028](0028-combined-exporter-reaches-into-sub-exporter-privates.md)
+and independent — 0028 is XS and should land first, as it always should have.
+
+## 5. Seams and testing decisions
+
+- **Seam:** the on-disk file, through `tests/exporters/test_jsonl_exporter.py`,
+  `test_chrome_trace_exporter.py` and `test_perfetto_exporter.py`, plus the JSONL leg of
+  `tests/test_convert_cmd.py`. That is the highest seam available and the correct one: the
+  contract this must not break is the file, not the class structure. The RSS warning is
+  observed at `tests/monitoring/test_monitoring_base.py`.
+- **New seam needed:** none. Do **not** assert on `__mro__`, on which class holds the buffer,
+  or on the method count — that pins the implementation this spec exists to make free to
+  change. *(carried from 0029)*
+- **What makes a good test here:** a golden-file comparison. Capture the JSONL a fixed set of
+  records produces today and assert the rewrite reproduces it byte for byte, including loss
+  records and instant events. "The file has three lines and parses as JSON" would pass on
+  output with every field name wrong. For the Perfetto leg, assert what the trace *means*
+  through the trace processor — a round-trip through our own constant is equally happy with a
+  right and a wrong field number ([ADR-0014](../docs/adr/0014-perfetto-integration-test-strategy.md)).
+- **Prior art:** `tests/exporters/test_combined_exporter.py` for the fan-out assertions;
+  `tests/test_convert_cmd.py` for the JSONL round-trip; the chrome↔perfetto content-equivalence
+  test in `tests/test_convert_cmd_perfetto.py`; `MockExporter` in `tests/helpers.py`, which is
+  the existing test adapter and which shrinks with the interface.
+- **Cases:**
+  1. Every record kind reaches every exporter that handles it, and the file is byte-identical
+     to today's for a fixed input on all five formats.
+  2. GC records, loss windows and instant events all reach the JSONL file when the buffer never
+     hits the flush threshold and `close()` is what drains it — the path each of the three
+     duplicated blocks owns today. *(carried from 0029)*
+  3. `close()` twice writes the file once; an `add` after `close()` does not resurrect the file.
+  4. An exporter that does not handle RSS drops the sample and does not raise, and
+     `run_monitoring_loop` warns exactly once for that format.
+  5. Regression guard: `--format chrome+perfetto` writes the same two files, and the Perfetto
+     integration suite passes with no track moved and no field number changed.
+
+## 6. Out of scope
+
+- Any change to the JSONL schema, including the `ts` unit. Both are public and documented.
+- `output_path` on the ABC — that is [0028](0028-combined-exporter-reaches-into-sub-exporter-privates.md),
+  independent and smaller, and it should land first.
+- Making an unhandled record kind raise instead of dropping. ADR-0008 settled that deliberately
+  and this spec does not reopen it.
+- Compression, rotation, or line-buffering policy for `--format stdout`. *(carried from 0029)*
+- The `EventEncoder` `Protocol` → `ABC` question. ADR-0008 chose the protocol deliberately.
+- Batching anything else the way liveness is batched. Liveness is batched because ADR-0011 made
+  it a per-tick observation; nothing else is.
+
+## 7. Further notes
+
+0029 is superseded rather than deleted, following the precedent
+[0034](0034-separate-interpreter-confirmation-from-loss-arithmetic.md) set. Its §4 carries the
+full argument for why JSONL must not move onto `TraceEvent`, which is the single most important
+constraint on this work and which a reader should have in front of them before touching
+`JsonlExporter`. When 0036 lands, both files go.

--- a/specs/0037-one-meta-emission-path-for-live-and-combined-traces.md
+++ b/specs/0037-one-meta-emission-path-for-live-and-combined-traces.md
@@ -1,0 +1,142 @@
+# 0037 — Build a trace's process and thread meta in one place
+
+- **Status:** Not started
+- **Kind:** feature — cleanup
+- **Effort:** M
+- **Origin:** code structure review of `src/gcmon`, 2026-08-15. Takes up what
+  [0026](0026-one-process-name-across-live-and-offline-paths.md) explicitly left out of scope.
+- **Respects:** [ADR-0007](../docs/adr/0007-shared-trace-converter-pipeline.md) (one conversion
+  pipeline; `ProcessMeta` precedes `ThreadMeta`),
+  [ADR-0008](../docs/adr/0008-buffered-exporter-and-encoder-protocol.md) (meta dedup lives in
+  the exporter base and is atomic; `combine` uses an encoder without an exporter),
+  [ADR-0012](../docs/adr/0012-trace-output-formats.md) (Perfetto output in `combine`)
+
+## 1. Problem statement
+
+gcmon has two implementations of "emit the process and thread meta for this pid", and they have
+already drifted once: [0026](0026-one-process-name-across-live-and-offline-paths.md) exists
+because a live capture names a process `Process 12345` and the same process combined from JSONL
+names it `12345`. 0026 fixes the two literals and says so — it puts the shared implementation
+out of scope deliberately, to stay XS. That leaves the mechanism that produced the drift in
+place, ready to produce the next one: the two paths also differ in *when* they emit thread meta
+(as each iid first appears, versus all of a pid's threads up front), and each will keep
+acquiring behaviour independently.
+
+`combine_files` compounds it by choosing its output encoder with its own `match` on the format
+string, duplicating the dispatch `EventsExporterFactory` already owns. A format added to one is
+not added to the other.
+
+## 2. Solution
+
+Nothing changes for an operator beyond what 0026 already promises. What changes is that
+"what meta does this pid need, and has it been emitted yet" is answered once, by one piece of
+code that both the live exporter and `gcmon combine` call, so a third divergence has nowhere to
+start.
+
+## 3. User stories
+
+1. As an operator comparing a live capture against a combined one, I want identical process and
+   thread metadata, so that a difference between the two traces is a real difference in the run.
+2. As a maintainer changing how a track is named or described, I want one place to change it,
+   so that the offline path cannot keep the old form.
+3. As a maintainer adding an output format to `combine`, I want the format dispatch to be the
+   one the live path already uses, so that a format cannot be supported live and missing
+   offline.
+4. As an operator running `gcmon combine` over a capture with several interpreters, I want the
+   thread rows to carry the same names they carry live, so that a PerfettoSQL query written
+   against one trace runs against the other.
+5. As a maintainer, I want the meta dedup to stay atomic under the exporter's state lock, so
+   that sharing the implementation does not reopen the race ADR-0008 closed.
+6. As a maintainer, I want the deprecated re-export shim gone once nothing needs it, so that
+   there are not two import paths for one function.
+
+## 4. Implementation decisions
+
+**4.1 — Extract the meta *decision*, keep the dedup *state* where it is.** The two paths differ in
+what they know: `BufferedTraceExporter._build_meta` owns per-`(pid, iid)` dedup state across a
+long run, while `trace_converter.convert_to_trace_format` has every record in hand at once and
+derives the thread set per pid. What they should not differ in is which meta events a given
+`(pid, iid)` needs and how they are named. Extract that into one function in `trace_event.py`,
+beside `process_meta` and `thread_meta` — the same home 0026 chose for
+`process_display_name(pid)`, which this generalizes.
+
+`_build_meta` keeps its `_seen_pids` / `_seen_tids` sets and its single critical section under
+`_lock`. ADR-0008 closed the check-and-emit race there and `TestMetaDedupRaceClosed` pins it;
+this must not move the emit outside that section. The batch path calls the same function with
+its own already-computed set.
+
+**4.2 — One encoder dispatch, still without an exporter.** `combine_files` stops matching on
+`output_format` itself and calls a shared `encoder_for(output_format)` used by both
+`EventsExporterFactory` and `combine_files`. This deliberately does **not** route `combine`
+through an `EventsExporter`: ADR-0008 chose composition precisely so an encoder can run without
+one, and `combine` has every event in memory and needs neither the buffer nor the flush
+threshold. Sharing the dispatch gets the benefit without overturning the record.
+
+**Rejected: feed `combine` through `EventsExporterFactory` and delete
+`convert_to_trace_format` outright.** It is the larger and more tempting change — it would make
+the offline path exercise the live code end to end, which is the strongest possible guard
+against divergence. It loses on two counts. It contradicts ADR-0008's consequence that the
+encoder protocol has no dependency on the exporter base, which was a decision and not an
+accident. And it gives `combine` a buffering lifecycle it has no use for, including an
+`add_process_liveness` call it has no source for. The fact that would settle it differently: a
+third consumer of the conversion pipeline appearing, at which point one shared path is worth
+more than the encoder's independence.
+
+**4.3 — Delete `chrome_trace_format.py`.** It is a re-export shim kept, per ADR-0007's
+consequences, "so existing importers keep working". The only importer inside `src/` is
+`chrome_trace_io`; the only one in `tests/` is
+`tests/exporters/test_chrome_trace_format.py`, which imports two names from it and a third from
+`trace_converter` directly, in the same file. Point both at `trace_converter` and delete the
+module. ADR-0007's consequence list gets a line saying the shim served its purpose and went.
+
+**4.4 — Ordering is preserved, not unified.** The live path interleaves thread meta with events
+as each iid first appears; the batch path emits a pid's thread meta before that pid's events.
+Both satisfy ADR-0007's contract that `ProcessMeta` precedes `ThreadMeta` for a pid, both
+produce the same trace once loaded, and changing either would move bytes for no operator
+benefit. Out of scope, stated here so nobody "fixes" it as part of this.
+
+## 5. Seams and testing decisions
+
+- **Seam:** `tests/test_convert_cmd_perfetto.py`, which already loads combine output into the
+  trace processor and queries the `process` and `thread` tables. Metadata is columns there, so
+  the assertion is about what the trace means rather than about our own literals — the highest
+  seam available, and the one 0026 picked for the same reason.
+- **New seam needed:** none.
+- **What makes a good test here:** assert *equality between the two paths* for the same pid and
+  iid, not two tests each asserting a literal — a literal test per path is exactly what let the
+  name drift happen and pass. Build the live events and the offline events for one pid with two
+  interpreters and compare the meta each produces as a set.
+- **Prior art:** the cross-path comparison 0026 specifies; the chrome↔perfetto
+  content-equivalence test in `tests/test_convert_cmd_perfetto.py`
+  ([ADR-0014](../docs/adr/0014-perfetto-integration-test-strategy.md));
+  `TestMetaDedupRaceClosed` in `tests/exporters/test_exporter_thread_safety.py` for the race
+  that must stay closed.
+- **Cases:**
+  1. Live and offline meta for one pid with interpreters 0 and 1 are equal as sets.
+  2. `TestMetaDedupRaceClosed` still passes: two threads adding events for a brand-new pid
+     produce one `ProcessMeta`.
+  3. `combine --output-format perfetto` and `--output-format chrome` both still work, and adding
+     a format to the shared dispatch makes it available to both `combine` and the live factory.
+  4. Regression guard: the Perfetto integration suite passes with no track moved; Chrome output
+     for a fixed capture is byte-identical apart from the process name 0026 changes.
+
+## 6. Out of scope
+
+- The process *name* itself. [0026](0026-one-process-name-across-live-and-offline-paths.md)
+  settles it, is XS, and should land first — this spec assumes its `process_display_name`
+  helper exists.
+- Routing `combine` through an `EventsExporter` (see §4.2, rejected with the condition that
+  would reopen it).
+- The two timestamp normalizers. `_normalize_trace_timestamps` works on `TraceEvent` and
+  `_normalize_jsonl_timestamps` on records; they exist because there are two representations,
+  not because of this duplication. [0035](0035-derive-every-gc-sub-phase-from-one-table.md)
+  turns the second into a table walk, which is most of the cost of the second one.
+- Naming a process after its cmdline. ADR-0010 territory, and 0026 already excluded it.
+- Emission ordering (see §4.4).
+
+## 7. Further notes
+
+0026, 0037 and [0036](0036-one-exporter-method-per-record-kind.md) all touch the exporter
+package and are independent. Order by size: 0026 (XS, one literal), then
+[0028](0028-combined-exporter-reaches-into-sub-exporter-privates.md) (XS), then this, then
+0036 — each leaves less for the next.

--- a/specs/0038-let-the-monitor-own-the-pid-lifecycle.md
+++ b/specs/0038-let-the-monitor-own-the-pid-lifecycle.md
@@ -1,0 +1,158 @@
+# 0038 — Let the monitor own the pid lifecycle
+
+- **Status:** Not started
+- **Kind:** feature — cleanup
+- **Effort:** M
+- **Origin:** code structure review of `src/gcmon`, 2026-08-15
+- **Respects:** [ADR-0011](../docs/adr/0011-process-lifetime-and-ordering.md) (liveness reported
+  once per tick, after the poll phase — **this moves the reporting site and the ADR is amended
+  with it**), [ADR-0013](../docs/adr/0013-rss-sampling.md) (the sampler is driven once per tick
+  from the same instant), [ADR-0015](../docs/adr/0015-gc-loss-spans-on-their-own-track.md)
+  (per-`(pid, iid, gen)` ring state)
+
+## 1. Problem statement
+
+Everything gcmon knows about a monitored pid has two owners. `EventsMonitor` keeps the ring
+state — the `collections` cursor and the last poll instant that ADR-0015's loss arithmetic runs
+on — while `MonitorLoop` keeps the wait policy that decides when that pid is finished, and each
+prunes its own half against the same set of child pids, computed twice per tick from the same
+listing.
+
+The hazard is a recycled pid. The monitor's own reason for having a `forget` method is that a
+reused pid must inherit no counter and no poll instant from the process before it: if it did,
+the next poll would compare a fresh process's `collections` counter against a dead one's cursor
+and report a loss window full of records that never existed — an operator would see a `GC
+Loss(0)` span claiming hundreds of missing collections in an interval where nothing was lost.
+Whether that can happen depends on the two prunes staying in agreement, and they are in
+different modules, computed from different expressions, with no test that compares them.
+
+`EventsMonitor` also exposes its exporter as a public property for one reason: so the loop can
+reach through it and report liveness.
+
+## 2. Solution
+
+Nothing changes for an operator: the same poll cadence, the same spans, the same trace. What
+changes is that one tick of monitoring is one call. The monitor answers "who was alive, and
+should I keep going", and owns every piece of per-pid state behind that answer. The loop is
+left with what it is for — timing and the stop signal.
+
+## 3. User stories
+
+1. As an operator monitoring a process tree that churns workers, I want a recycled pid to start
+   from nothing, so that gcmon never reports a loss window for collections that never happened.
+2. As a maintainer, I want per-pid state pruned once against one set, so that two prunes cannot
+   disagree.
+3. As a maintainer, I want the exporter to stop being reachable through the monitor, so that
+   the only code emitting to it is the code that owns what it emits.
+4. As a maintainer reading `MonitorLoop`, I want to see timing and shutdown, so that the file's
+   subject is what its name says.
+5. As a maintainer writing a test for poll behaviour, I want to drive one method and assert on
+   its report, so that a test does not have to reproduce the loop's orchestration to exercise
+   the monitor.
+6. As an operator, I want the RSS sampler to keep pacing off the same instant the trace is
+   stamped with, so that a sample and a liveness observation from one tick agree.
+7. As a maintainer, I want a wait policy's lifetime tied to the pid it judges, so that a pid
+   the policy gave up on cannot be re-polled by a fresh policy that answers "still starting".
+
+## 4. Implementation decisions
+
+**4.1 — One tick, one call.** `EventsMonitor` gains a method that performs a whole tick and
+returns a small report: the pids that answered `PollStatus.OK`, and whether any policy still
+wants the loop to continue.
+
+```python
+class PollReport(msgspec.Struct):
+    live_pids: frozenset[int]   # answered OK this tick
+    keep_running: bool          # any wait policy still holds the loop open
+```
+
+It absorbs, in the order the loop runs them today: child discovery, the prune of both the ring
+state and the wait policies against the child set, the per-pid enable check, the poll, the
+policy verdict, `forget` for a pid the policy gave up on, and the liveness report. The loop
+keeps the clock, the stop event, the rate, the RSS sampler and the `keep_running` break.
+
+**4.2 — The wait policies move to the monitor, and so does the enable predicate.** The policy is
+per-pid state whose lifetime is exactly the ring state's lifetime; that is what makes the double
+prune possible. The control-plane predicate moves with it, which also removes a genuine reading
+hazard: `EventsMonitor._enabled` is a bool meaning "not stopped" and `MonitorLoop._enabled` is a
+per-pid callable meaning "the control server has not suppressed this pid". Two fields, one name,
+two modules, unrelated meanings. The monitor keeps the flag and takes the predicate under a name
+that says which it is.
+
+**4.3 — `EventsMonitor.exporter` goes.** Its only caller is the loop's liveness call, which
+moves inside. Nothing else reaches through it.
+
+**4.4 — ADR-0011's constraints are preserved exactly, and the ADR is amended to match.** The
+record anchors liveness reporting on `MonitorLoop` by name, in its liveness section and its
+implementation notes, so moving the call is a name move and ADR-0011 gets amended rather than
+contradicted — the ADR README's rule for exactly this case. What must not change: one
+`time.monotonic_ns()` per tick; liveness reported **after** the poll phase, never during it;
+the call skipped on an empty live set; and the same instant handed to the RSS sampler in
+seconds. The ADR's note that a batch crossing `flush_threshold` mid-poll can still emit a
+rank-less descriptor stays true, and stays true for the same reason.
+
+**4.5 — `create_monitor` goes.** It forwards three arguments to the constructor and adds
+nothing. It is re-exported from `gcmon/__init__.py`, so it stays as a name for one release,
+aliased to the class, and the `__all__` entry goes when it does.
+
+**Rejected: leave the split and add a test that the two prunes agree.** It pins the coupling
+rather than removing it, and it can only compare the two expressions on inputs a test thinks
+of. The prune is one operation; it should be written once.
+
+**Rejected: move the timing into the monitor as well, leaving `MonitorLoop` a shell.** The
+`Runner` seam (`run_policy`) is what makes a duration-limited run testable without waiting, and
+the stop event is what the signal handler sets. Both belong to the loop. Two modules is the
+right number; the line between them is what is wrong.
+
+**Open, to settle when picked up:** whether `PollReport` carries the live set as a `frozenset`
+or the loop keeps taking a `set`. `RssSampler.tick` takes `set[int]` today. Settled by whether
+anything mutates it — nothing does, so `frozenset` unless the sampler's signature is more
+disruptive to change than it is worth.
+
+## 5. Seams and testing decisions
+
+- **Seam:** `tests/monitoring/test_monitor_loop.py` and `tests/monitoring/test_monitor.py`,
+  with `MockExporter` from `tests/helpers.py` recording what was emitted. This is the highest
+  seam that can observe the behaviour: the defect class is per-pid state management, which
+  produces no trace bytes of its own — it corrupts the *next* poll's loss arithmetic, which is
+  observable at the exporter.
+- **New seam needed:** none. `PollReport` is a return value at an existing seam, not a new one;
+  it replaces assertions that currently reach into loop-local dicts.
+- **What makes a good test here:** drive several ticks with a scripted child-pid listing and
+  assert on what reached the exporter — specifically that a pid which disappears and returns
+  produces **no** loss window on its first poll back. A test that asserts the internal state
+  dicts are empty proves the prune ran, not that the prune was correct; the observable
+  consequence is the absence of a fabricated `GC Loss` span.
+- **Prior art:** `tests/monitoring/test_monitor_loop.py` for driving ticks against a fake
+  runner; `tests/test_loss_replay.py` and `tests/captures.py` for replaying a known capture and
+  asserting the reconstruction; `tests/monitoring/conftest.py` for the monitor mock.
+- **Cases:**
+  1. A pid that exits and whose number is reused starts from a clean cursor: its first poll
+     back emits records and no loss window.
+  2. A pid the wait policy gives up on is not re-polled by a fresh policy on the next tick.
+  3. A failed child listing prunes nothing — today's `None` means "no answer", and a tick that
+     cannot enumerate children must not drop state for pids it simply could not see.
+  4. Liveness is reported once per tick, after the polls, skipped when nothing answered OK, and
+     stamped with the same instant the RSS sampler paced off.
+  5. Regression guard: a full monitored run over `tests/captures.py` produces the same trace it
+     does today, byte for byte on the Chrome leg.
+
+## 6. Out of scope
+
+- The loss arithmetic itself. `RingAccumulator` and ADR-0015 are untouched; this changes who
+  owns the accumulator's lifetime, not what it computes.
+- The `Runner` / `WaitPolicy` protocols. Their shape is right; only where the policy instances
+  live changes.
+- The control plane. `ControlServer.is_enabled` keeps its signature; only the caller moves.
+- Making the monitor thread-safe. It is driven from one loop today and this does not change
+  that.
+- Anything about child-process discovery itself, including whether `get_child_pids` should be
+  cached across ticks.
+
+## 7. Further notes
+
+The two-prune hazard is currently latent rather than live: today both prunes derive from the
+same `children` list within one tick, so they agree. It is a structural risk, not a bug report —
+the fix is worth doing because the next edit to either module is what would separate them, and
+the failure it produces (a fabricated loss window) looks like a gcmon measurement rather than a
+gcmon bug.

--- a/specs/0039-split-the-record-model-and-stats-by-concern.md
+++ b/specs/0039-split-the-record-model-and-stats-by-concern.md
@@ -1,0 +1,137 @@
+# 0039 — Split the record model and the stats module by concern
+
+- **Status:** Not started
+- **Kind:** feature — cleanup
+- **Effort:** S
+- **Origin:** code structure review of `src/gcmon`, 2026-08-15
+- **Respects:** [ADR-0009](../docs/adr/0009-nanoseconds-canonical-time-unit.md) (names the
+  module holding the ns→µs conversion — **amended, not contradicted**),
+  [ADR-0015](../docs/adr/0015-gc-loss-spans-on-their-own-track.md) (names the modules holding
+  the loss record and the gap accounting — likewise)
+
+## 1. Problem statement
+
+Two modules have accumulated three jobs each, and the cost shows up as import fan-out. `data`
+holds the record structs, the JSONL decoder, the unit conversions and the Perfetto arg text —
+so the Perfetto encoder imports it to get `ts_to_us`, the control server imports it to build an
+instant message, and `stats` imports it to convert seconds to nanoseconds. Three modules with
+nothing in common depend on one module for three unrelated reasons, and each of them drags the
+whole record model in behind it.
+
+`stats` is the same shape at larger scale: a percentile accumulator that has nothing to do with
+GC, nine metric adapters that are a name and a two-field getter apiece, and the streaming
+aggregation with its loss and lifetime bookkeeping. The test package already knows this —
+`tests/stats/` is split into `test_stats.py`, `test_metrics.py`, `test_streaming_stats.py` and
+`test_stats_output.py`, four files along a seam the source does not have.
+
+Nothing an operator sees is wrong. The cost is that every one of these modules is on the import
+path of things that need a tenth of it, and a reader looking for the percentile logic opens a
+file that starts with GC field guards.
+
+## 2. Solution
+
+No behaviour changes at all — this is a move. What changes is that a module's name predicts its
+contents, an importer takes on the dependency it actually wants, and the source layout matches
+the test layout that already exists.
+
+## 3. User stories
+
+1. As a maintainer looking for the percentile accumulator, I want it in a file named for it, so
+   that I do not read past two hundred lines of GC field handling to reach it.
+2. As a maintainer of the Perfetto encoder, I want to import a unit conversion without pulling
+   in the record model, so that the dependency graph says what the code actually needs.
+3. As a maintainer of the control plane, I want to build an instant message without importing
+   the statistics vocabulary, so that a change to the record model does not touch the control
+   server's imports.
+4. As a maintainer adding a test, I want the source file layout to match `tests/stats/`, so
+   that I know which file a new test belongs beside.
+5. As someone reading gcmon for the first time, I want the record model in one place and the
+   presentation strings somewhere else, so that "what is a record" is answerable without
+   reading the Perfetto arg formatting.
+6. As a maintainer, I want the ADRs that anchor on these module paths updated in the same
+   change, so that a record does not point at a file that no longer exists.
+
+## 4. Implementation decisions
+
+**4.1 — `data` splits three ways.**
+
+| New home | Contents | Imported by |
+|---|---|---|
+| the record model | `GCStatsInfo`, `InstantMsg`, `GenLoss`, `LossMsg`, `from_mapping`, `instant_msg` | monitor, loss, control server, the JSONL reader |
+| the unit conversions | `ts_to_us`, `dur_to_ms`, `secs_to_ns` | the JSON encoder, stats, stats output, loss |
+| the slice text | `duration_text`, `seen_text`, `missing_collections` | `trace_converter`, and only `trace_converter` |
+
+The slice text is presentation for a `GC Loss` slice's args and has exactly one caller. It goes
+beside that caller rather than into a module of its own — `duration_text`'s docstring already
+describes itself as "the way the Perfetto UI writes a duration", which is a statement about the
+consumer, not about gcmon's data.
+
+**4.2 — `stats` becomes a package with three modules**, matching `tests/stats/`: the
+accumulator (`Stats`, `get_quantile_value`, the DDSketch fallback), the metric table, and the
+streaming aggregation (`StreamingStats`, `LossTotals`, `PauseTotals`, `LifetimeTotals` and the
+two key aliases). `stats_output` stays where it is — it is presentation and it already has one
+job.
+
+**4.3 — The metric table is whatever [0035](0035-derive-every-gc-sub-phase-from-one-table.md)
+leaves.** If 0035 has landed, this module is the derivation from the phase table and is a few
+lines; if it has not, it is the nine `Metric` classes moved verbatim. Either way this spec does
+not change what a metric is. **0035 should land first** — it deletes most of what would
+otherwise be moved.
+
+**4.4 — Public re-exports are preserved.** `gcmon/__init__.py` exports a fixed `__all__`; every
+name in it keeps working from `gcmon` directly. `gcmon.data` and `gcmon.stats` keep re-exporting
+their old contents for one release, then go.
+
+**4.5 — Three ADR implementation notes are amended in the same change.** ADR-0009 names the
+module holding the ns→µs conversion; ADR-0015 names the modules holding the loss record and the
+gap accounting. The ADR README's rule is explicit: amend a record when a name it anchors on
+moves. This is a rename inside the implementation section of each, not a change of decision.
+
+**Rejected: leave `data` alone and only split `stats`.** The unit conversions are the reason the
+Perfetto encoder imports the record model, and they are three functions. Splitting the larger
+module while leaving the smaller cross-layer dependency in place gets the less useful half.
+
+**Rejected: one module per struct.** `GenLoss` and `LossMsg` are one record type in two pieces
+and are read together everywhere; separating them would be layout for its own sake.
+
+## 5. Seams and testing decisions
+
+- **Seam:** the existing suite, unchanged except for imports. There is no behaviour here to
+  observe, so the highest available seam is "every test that passed still passes, with no test
+  body edited". A test body that has to change is evidence something moved that should not have.
+- **New seam needed:** none, and none is wanted. Do not add tests asserting that a module
+  exports a given name — that pins the layout this spec is choosing, and the next reorganization
+  would have to delete them.
+- **What makes a good test here:** nothing new. The value is in what is *not* required: if this
+  move needs a new test, it was not a move. The one thing worth checking mechanically is that
+  the public surface is unchanged — `gcmon.__all__` still resolves, every name in it importable
+  from `gcmon` directly.
+- **Prior art:** `tests/stats/` is already the four-way split this creates in the source;
+  `tests/test_data.py` covers the record model and the conversions together and splits along the
+  same line.
+- **Cases:**
+  1. The full suite passes with import lines updated and no test body changed.
+  2. Every name in `gcmon.__all__` imports from `gcmon` directly, as it does today.
+  3. Regression guard: `gcmon run` over a fixture produces byte-identical output on all five
+     formats. A pure move that changes a byte has moved something else too.
+
+## 6. Out of scope
+
+- Which package these modules end up in. This splits by concern; placing the results into
+  layers is [0041](0041-give-the-package-explicit-layers.md), which should land after and which
+  this makes tractable.
+- The phase table. [0035](0035-derive-every-gc-sub-phase-from-one-table.md) owns it and should
+  land first.
+- `chrome_trace_io`, which has the same grab-bag shape (JSONL read, JSONL write, Chrome parse,
+  two normalizers, combine orchestration). Most of it is claimed by
+  [0037](0037-one-meta-emission-path-for-live-and-combined-traces.md) and 0035; splitting what
+  survives is worth doing then, with the remainder in view.
+- Splitting `perfetto_format`, which [0030](0030-exporter-hygiene-batch.md) already named and
+  deferred.
+- Any change to the JSONL schema, the `--stats` table or the Perfetto arg strings. All three are
+  public and this moves code, not output.
+
+## 7. Further notes
+
+Sequence matters more than usual here: 0035 → 0039 → 0041. Doing 0039 first means moving nine
+`Metric` classes that 0035 deletes; doing 0041 first means moving files twice.

--- a/specs/0040-derive-the-monitoring-options-from-one-table.md
+++ b/specs/0040-derive-the-monitoring-options-from-one-table.md
@@ -1,0 +1,145 @@
+# 0040 — Derive the monitoring options from one table, and validate before reporting
+
+- **Status:** Not started
+- **Kind:** feature — cleanup
+- **Effort:** M
+- **Origin:** code structure review of `src/gcmon`, 2026-08-15
+- **Respects:** [ADR-0012](../docs/adr/0012-trace-output-formats.md) (which formats exist),
+  [ADR-0013](../docs/adr/0013-rss-sampling.md) (RSS behind a flag with an interval)
+
+## 1. Problem statement
+
+Run `gcmon run -s app.py -v --rate -1` and gcmon reports the configuration it is about to use —
+`Format: chrome`, `Rate: -1.0s`, `Duration: until script exits` — and then refuses to start
+because the rate must be positive. The echo is not a preview of a rejected configuration; it is
+the same echo a successful run prints, emitted before anything is checked. An operator reading a
+log has to reach the last line to know whether the lines above it describe a run that happened.
+
+Behind it, every monitoring option is written out three times: once as a `get_env_*` function,
+once as an `add_argument` block whose help text re-names the same environment variable, and once
+as a constructor parameter, a field assignment and a keyword at the call site. `monitoring_options`
+imports twenty-two names from the environment module to do it — the widest import in the
+codebase. Adding an option means eight edits in three files, and the failure mode is an option
+that works on the command line and silently ignores its environment variable, or the reverse.
+
+## 2. Solution
+
+An operator sees one difference: the configuration echo appears only for a configuration gcmon
+accepted. A rejected run prints the error and nothing else. Everything else — flag names,
+defaults, help text, environment variables, exit codes — is unchanged.
+
+For a maintainer, an option becomes one row: its flag, its environment variable, its type, its
+default and its help text, with argparse wiring and environment defaults both derived from it.
+
+## 3. User stories
+
+1. As an operator reading a verbose log, I want the configuration echo to describe a run that
+   actually started, so that I can tell an aborted invocation from a completed one at a glance.
+2. As an operator who mistyped a rate, I want the error and nothing above it, so that the
+   failure is the first thing I see.
+3. As a maintainer adding a monitoring option, I want to add one row, so that its flag and its
+   environment variable cannot disagree about the default.
+4. As a maintainer, I want an option's help text to name its environment variable without my
+   writing the name twice, so that renaming the variable cannot leave the help stale.
+5. As an operator relying on `GCMON_*` variables in CI, I want every one of them to keep working
+   exactly as documented, so that this is not a migration.
+6. As a maintainer of the `run` and `monitor` commands, I want option validation to raise rather
+   than return `None`, so that a new command cannot forget the `if options is None` check and
+   start a run with an unvalidated configuration.
+7. As a maintainer, I want the options object to be a frozen struct like every other data
+   carrier in gcmon, so that nothing downstream can mutate a validated configuration.
+8. As an operator running `--help`, I want output identical to today's, so that scripts and
+   documentation that quote it stay accurate.
+
+## 4. Implementation decisions
+
+**4.1 — One `Option` row per option.** Flag names, destination, environment variable, parser,
+argparse action, default and help template in one tuple; the argparse wiring and the environment
+default both derive from it. The help template carries a placeholder for the environment
+variable name so the name is written once, which is the part that currently rots.
+
+The rows are irregular in exactly three ways and the shape has to carry them: `--verbose` is
+`action="count"`, `--stats` and `--rss` are `store_true`, and `--table-format` parses through
+`_normalize_table_format`, which raises `argparse.ArgumentTypeError` and must keep doing so —
+that is what produces argparse's own error message for a bad value. An `action` field and a
+`parser` field cover all three.
+
+**4.2 — `MonitoringOptions` becomes a frozen `msgspec.Struct` with a `from_args` classmethod.**
+It is a ten-field hand-written `__init__` in a codebase where every other data carrier is a
+struct. `from_args` validates and raises a module-level error type; the caller catches once.
+Today each command writes `options = get_monitoring_options(...)` followed by `if options is
+None: return 1`, which is a check a third command can omit without anything noticing.
+
+**4.3 — Validate, then describe.** `from_args` validates. A separate `describe()` returns the
+lines the commands log, and the commands log them only after construction succeeds. This is the
+operator-visible half of the spec and the only behaviour change in it.
+
+The order of the checks themselves is preserved, so an invocation with two bad values reports
+the same one it reports today.
+
+**4.4 — The RSS format-capability warning is not part of this.** It is the one line in
+`get_monitoring_options` that is not validation — it asks whether the chosen format will discard
+RSS samples, using a hand-maintained tuple of format names.
+[0036](0036-one-exporter-method-per-record-kind.md) moves that question to the exporter, which
+can answer it. If 0036 lands first, the line is already gone; if not, it moves into `describe()`
+verbatim and 0036 removes it from there. Either order works.
+
+**4.5 — Environment variable names and semantics are frozen.** Every `GCMON_*` name, every
+accepted truthy spelling (`1`, `yes`, `on`, `true`), every default. They are documented in
+[docs/cli.md](../docs/cli.md) and in the help text, and `tests/test_env.py` pins them.
+
+**Rejected: a settings library.** It would replace a table gcmon controls with a dependency's
+opinions about precedence and error text, for eleven options, and gcmon's runtime dependency
+tree is deliberately small ([ADR-0001](../docs/adr/0001-hand-rolled-perfetto-protobuf-encoder.md)
+made the same call for protobuf).
+
+**Rejected: generating the environment variable name from the flag** (`--rss-interval` →
+`GCMON_RSS_INTERVAL`). It holds for all eleven today, which is precisely why it is a trap: the
+first option that needs to differ would force the convention back open, and the saving is one
+short string per row.
+
+## 5. Seams and testing decisions
+
+- **Seam:** `tests/test_cli.py`, at the command line — the highest seam available, because
+  everything here exists to turn an argv and an environment into a configuration, and that is
+  observable from outside. `tests/test_env.py` and
+  `tests/monitoring/test_monitoring_options.py` cover the environment defaults and the
+  validation rules at the level they are written today.
+- **New seam needed:** none.
+- **What makes a good test here:** drive `main()` with an argv and a patched environment and
+  assert on exit code and emitted log lines. A test that reads a default out of the option table
+  and compares it to the same table proves nothing — assert the *resolved* value after parsing,
+  which is what an operator gets. For the ordering change, assert that a rejected invocation
+  emits the error and **no** configuration lines; asserting the error appears is not enough,
+  since it appears today too.
+- **Prior art:** `tests/test_env.py` for the environment-variable matrix;
+  `tests/monitoring/test_monitoring_options.py` for the validation cases and the
+  `RSS_CAPABLE_FORMATS` parametrization; `tests/test_cli.py` for driving `main()` end to end.
+- **Cases:**
+  1. Every option resolves identically from a flag, from its environment variable, and from
+     neither — the same matrix `tests/test_env.py` covers today, unchanged.
+  2. A flag overrides its environment variable, as today.
+  3. `--rate -1` exits 1, prints the rate error, and prints no configuration lines.
+  4. Two invalid options report the same one reported today.
+  5. `--table-format nonsense` still fails through argparse with argparse's message.
+  6. Regression guard: `gcmon run --help` and `gcmon monitor --help` are byte-identical to
+     today's output. Capture both as golden files first — the help text is the public surface
+     this refactor is most likely to move by accident.
+
+## 6. Out of scope
+
+- Adding, removing or renaming any option, environment variable or default.
+- The `run` command's argv split (`_split_run_args`), which is about passing arguments to the
+  target and has nothing to do with option declaration.
+- The `combine` command's options, which are declared inline in its own module and are not
+  shared with anything.
+- Logging setup and verbosity handling in `cli`, beyond `--verbose` being a row in the table.
+- The RSS capability warning's correctness — [0036](0036-one-exporter-method-per-record-kind.md)
+  owns that.
+
+## 7. Further notes
+
+The echo-before-validate ordering is the only operator-visible change in the spec and it is
+cosmetic; it is filed here rather than as its own bug because the fix is a consequence of
+separating validation from reporting, and doing it alone would mean touching the same function
+twice.

--- a/specs/0041-give-the-package-explicit-layers.md
+++ b/specs/0041-give-the-package-explicit-layers.md
@@ -1,0 +1,160 @@
+# 0041 — Give the package explicit layers, and a test that keeps them
+
+- **Status:** Not started
+- **Kind:** feature — cleanup
+- **Effort:** L
+- **Origin:** code structure review of `src/gcmon`, 2026-08-15
+- **Respects:** every ADR that anchors on a module path — see §4.4, which is most of the work
+
+## 1. Problem statement
+
+`src/gcmon` is seventeen modules in one flat namespace, and they belong to five different
+layers: the record model, acquisition, analysis, output, and the command line. A reader cannot
+tell from the listing that `trace_event` is a data model and `rss_sampler` is a driver, or that
+`protocol` is at the bottom of everything and `commands` at the top.
+
+The layering itself is not broken — it is invisible. Walking the intra-package imports and
+ordering them as §4.1 does yields **zero** upward imports today: the dependency direction is
+already clean. Nothing states that, nothing checks it, and the first edit that reaches upward
+will land without comment. That is the cost: a property the codebase currently has, held by
+nobody, documented nowhere, and one import away from being lost quietly.
+
+## 2. Solution
+
+No behaviour change of any kind. What changes is that the directory listing states the
+architecture, and a test fails when an import crosses a layer the wrong way — so the property
+the codebase has today is one it keeps.
+
+## 3. User stories
+
+1. As someone reading gcmon for the first time, I want the directory names to tell me what the
+   layers are, so that I can find the acquisition code without opening seventeen files.
+2. As a maintainer adding a module, I want the directory I put it in to determine what it may
+   import, so that placement is a decision rather than a habit.
+3. As a maintainer who accidentally imports the CLI from the record model, I want a test
+   failure naming both modules, so that the mistake costs a minute and not a release.
+4. As a reviewer, I want a dependency inversion to show up as a failing test rather than as
+   something I have to notice, so that review attention goes to the change itself.
+5. As a maintainer of the record model, I want it to import nothing else in gcmon, so that it
+   stays the thing everything can depend on.
+6. As a maintainer reading an ADR's implementation notes, I want the module paths it names to
+   exist, so that a record stays checkable against the code.
+7. As an operator, I want this to be invisible, so that nothing about my traces, my flags or my
+   output changes.
+
+## 4. Implementation decisions
+
+**4.1 — Five layers plus a support leaf, as a partial order rather than a ranking.** The allowed
+edges, all of which exist today and every one of which was verified:
+
+| Layer | Holds | May import |
+|---|---|---|
+| support | the signal, termination and exit helpers | nothing in gcmon |
+| model | the record structs, the structural protocols, the phase table, units, the loss accumulator, the trace-event union, the poll status | support |
+| export | the exporters, encoders and converters | model, support |
+| analysis | the stats accumulator, the streaming aggregation, the stats table | model, support |
+| control | the parent-side server and child-side client | model, export, support |
+| capture | the monitor, the loop, the process handles, the wait and run policies, the RSS sampler | model, export, analysis, control, support |
+| integrations | the pyperf hook | everything below |
+| cli | the entry point, the subcommands, the environment defaults | everything below |
+
+Two edges are worth stating because they look wrong and are not: `capture` imports `export`
+because the monitor writes through an exporter, and `control` imports `export` because the
+control server turns a child's message into an instant event. Both are downward.
+
+`export` and `analysis` have no edge between them in either direction. They are siblings, not a
+sequence, which is why this is a partial order — a numeric rank would invent an ordering the
+code does not have and would make one of the two look subordinate.
+
+**4.2 — The test is the point; the directories are how it stays readable.** A new test walks
+`src/gcmon/**/*.py` with `ast`, maps each module to its layer by path, and asserts every
+intra-package import goes down or sideways within the allowed edges. It parses rather than
+imports, so it is fast, has no import side effects, and needs no optional dependency
+installed — it must **not** go behind a marker, since a deselected test catches nothing
+([ADR-0014](../docs/adr/0014-perfetto-integration-test-strategy.md) made that mistake once).
+The failure message names the importing module, the imported module and the edge that is not
+allowed.
+
+The table of allowed edges lives in the test, not in the source. It is a statement about the
+architecture and the test is where a statement about the architecture can fail.
+
+**4.3 — Public imports keep working.** `gcmon/__init__.py`'s `__all__` is the public surface and
+every name in it stays importable from `gcmon` directly. Deeper paths that tests and downstream
+code use today — `gcmon.data`, `gcmon.exporters.exporter`, `gcmon.protocol` — keep working
+through re-export shims for one release, then go. That is the same treatment
+[0039](0039-split-the-record-model-and-stats-by-concern.md) gives its moves.
+
+**4.4 — The documentation is most of the work, and the effort estimate says so.** The ADRs
+anchor on module paths deliberately: the ADR README requires it, and requires amending a record
+when a name it anchors on moves. Fourteen ADRs and the prose docs carry **62** lines naming
+`src/gcmon/…` paths, led by ADR-0011 with nine and ADR-0013 with seven. Every one of those is
+an amendment in this change, not a follow-up. A reshuffle that lands with the ADRs still
+pointing at the old paths has made the records worse, which is a larger loss than the layout is
+a gain.
+
+**Rejected: the test without the directories.** It would work — the layers can be a mapping from
+module name to layer in the test file. It leaves the architecture legible only to someone who
+opens the test, which is the situation this spec exists to end.
+
+**Rejected: the directories without the test.** The layering already holds by accident; making
+it visible without making it checkable protects it for exactly as long as everyone remembers.
+
+**Rejected: a lint plugin (import-linter or similar).** One more dependency and one more
+configuration format to hold a rule that is thirty lines of `ast` and expressible in the
+project's own vocabulary. gcmon hand-rolled a protobuf encoder to avoid a dependency
+([ADR-0001](../docs/adr/0001-hand-rolled-perfetto-protobuf-encoder.md)); a dependency for this
+would be out of character.
+
+**Open, to settle when picked up:** whether `integrations` is a layer or whether the pyperf hook
+simply sits at the CLI level. It is the only member and it imports from four layers below, which
+is the CLI's profile. Settled by whether a second integration ever appears.
+
+## 5. Seams and testing decisions
+
+- **Seam:** a new one — the module graph, read with `ast`. Nothing existing can observe an
+  import direction: the suite exercises behaviour, and every arrangement of these modules
+  produces the same behaviour. This is the case the conventions leave room for, and it is placed
+  as high as it can be, at the package rather than at any module.
+- **New seam needed:** yes, and this is the spec's one exception to "prefer an existing seam".
+  It is a single test file with no fixtures, no imports of the package under test, and no
+  optional dependencies. Nothing else in the repo grows a seam.
+- **What makes a good test here:** assert the *edge*, not the file layout. A test that lists the
+  expected directories would fail on any future reorganization for no reason; a test that
+  asserts `model` never imports `cli` keeps meaning the same thing however the files move.
+  Failure output must name both modules and the disallowed edge — a bare "layering violation"
+  costs more to diagnose than the rule saves.
+- **Prior art:** none in this repo for a structural test. The closest in spirit is
+  [0028](0028-combined-exporter-reaches-into-sub-exporter-privates.md)'s walk over
+  `EventsExporter.__subclasses__()` to assert every exporter answers `output_path` — a test
+  about the shape of the code rather than about an output, discovered rather than listed.
+- **Cases:**
+  1. The current tree passes with zero violations. That is the day-one state and the test's
+     first job is to record it.
+  2. A deliberately added upward import — the record model importing the CLI — fails with both
+     module names in the message.
+  3. A sideways import between `export` and `analysis` fails, since they have no edge.
+  4. Regression guard: the full suite passes with only import lines changed, and `gcmon run`
+     over a fixture produces byte-identical output on all five formats.
+
+## 6. Out of scope
+
+- Splitting any module. [0039](0039-split-the-record-model-and-stats-by-concern.md) splits the
+  record model and the stats module by concern; this places the results. **0039 should land
+  first**, or the same files move twice.
+- Changing what any module does. Every violation this could surface is hypothetical: there are
+  none today.
+- The `stats_output` dependency in the environment-defaults module, which imports it for the
+  table-format enum. Under these edges it is legal — the CLI may import analysis — so this
+  spec's test would not flag it. Worth noting because it is the one place an option's type
+  lives in a presentation module, and worth leaving alone until something makes it matter.
+- Any public API change beyond the re-export shims in §4.3.
+- Enforcing anything else with the same test: no cycle detection, no fan-out limits, no
+  file-size rules. One rule, one failure message.
+
+## 7. Further notes
+
+The honest case for this spec is weaker than for the others in this set, and it should be
+picked up last. It fixes nothing — it makes an existing property explicit and adds a guard.
+Its cost is real and mostly documentary: 62 ADR and docs lines, every import line in the
+package, and a permanent discontinuity in `git blame`. Worth doing when the package is
+otherwise settled; not worth doing between two of the changes that actually move code.

--- a/specs/0042-name-the-process-session-for-its-role.md
+++ b/specs/0042-name-the-process-session-for-its-role.md
@@ -1,0 +1,138 @@
+# 0042 — Name the process-session interface for its role, and trim it to it
+
+- **Status:** Not started
+- **Kind:** feature — cleanup
+- **Effort:** S
+- **Origin:** code structure review of `src/gcmon`, 2026-08-15
+- **Respects:** [ADR-0011](../docs/adr/0011-process-lifetime-and-ordering.md) (a monitored pid's
+  lifetime), [ADR-0012](../docs/adr/0012-trace-output-formats.md) — neither is affected; listed
+  because both name the monitored process
+
+## 1. Problem statement
+
+The abstraction over "the process gcmon is monitoring" is named for something it is not, and the
+names cost a reader more than the abstraction saves. `ProcessFactory` has `start`, `returncode`,
+`wait` and the context-manager pair: it is a session that owns a process for the length of a
+run, and it is a factory only in that one of its five members returns something.
+`ProcessRunnerFactory` is then a factory *of* that, so both commands write the same three-line
+closure to satisfy it.
+
+The two adapters behind the seam do not have the same shape, which is what makes the naming bite.
+Attaching to an existing pid is served by a class that subclasses the `TargetProcess` protocol
+*and* satisfies `ProcessFactory`, returning itself from `start`. Spawning a child is served by a
+class that satisfies `ProcessFactory`, is not a `TargetProcess`, and returns a separate one. A
+reader has to hold both arrangements to know what `factory(control_address).start()` gives them.
+
+The interface is also missing a fact its caller depends on: an attached target's `returncode` is
+permanently `None` and its `wait` does nothing, so `gcmon monitor <pid>` always exits 0 whatever
+the target does. That is correct — gcmon does not own a process it attached to — but it is
+discoverable only by reading both adapters.
+
+## 2. Solution
+
+Nothing changes for an operator: the same two ways to name a target, the same exit codes, the
+same output. What changes is that the seam is named for the role it fills, one adapter is not
+two roles at once, and the interface states what a caller must know rather than leaving it to be
+inferred from the implementations.
+
+## 3. User stories
+
+1. As a maintainer reading the monitoring entry point, I want the type of the thing being
+   started to be named for what it is, so that I am not looking for a factory that is not there.
+2. As a maintainer adding a third way to name a target, I want one interface with one shape, so
+   that I do not have to decide whether my class should also be its own target.
+3. As a maintainer, I want to know from the interface that an attached target reports no exit
+   code, so that I do not write a caller that waits on one.
+4. As a maintainer of the `run` and `monitor` commands, I want to hand the monitoring entry point
+   the thing it needs directly, so that both commands do not carry the same closure to satisfy a
+   name.
+5. As a maintainer, I want the child-process adapter to expose the interface and not eight extra
+   members, so that a caller cannot come to depend on something the other adapter does not have.
+6. As an operator running `gcmon monitor <pid>`, I want the exit code to stay 0 regardless of what
+   the attached process does, so that this refactor does not change my CI.
+7. As an operator running `gcmon run`, I want the target's exit code to keep propagating, so that
+   a failing script still fails the command.
+
+## 4. Implementation decisions
+
+**4.1 — `ProcessFactory` becomes a session.** Renamed to say so, with its five members unchanged:
+start it, wait on it, read its return code, use it as a context manager. Its docstring carries
+what the interface actually requires of a caller — including that `returncode` may be `None`
+forever, and what that means for the two adapters.
+
+**4.2 — `ProcessRunnerFactory` becomes what both call sites already write.** It is
+`Callable[[str], <session>]`, the control address being the one thing the session needs from the
+monitoring setup. Both commands stop defining an identically-shaped local closure to satisfy a
+named protocol and hand over a partially-applied constructor instead.
+
+**4.3 — The attach adapter stops being its own target.** Today it subclasses the `TargetProcess`
+protocol and returns itself from `start`, so one class fills two roles. Give it the same shape as
+the spawn adapter: a session that starts and returns a target. The target for an attached pid is
+a two-line object holding the pid, which the child-process path already has an equivalent of.
+Two adapters, one shape.
+
+**4.4 — `TargetProcess`, `ProcessFactory` and `WaitPolicy` lose `runtime_checkable`.** Nothing
+in `src/` or `tests/` calls `isinstance` against any of them — the only protocol-adjacent
+`isinstance` in the suite is against the two concrete runner classes. `runtime_checkable` on a
+protocol nobody checks at runtime is a decoration that suggests a capability the code does not
+use, and it silently weakens the check it appears to offer, since it tests for method presence
+and not signatures.
+
+**4.5 — The child adapter is trimmed to the session interface.** It exposes `process`, `pid`,
+`is_running` and `close` beyond it. `close` is an alias for `terminate`, and the other three have
+no caller in the monitoring flow — only its own tests. Trimming them makes the two adapters
+substitutable in fact and not only in principle. Where a test genuinely needs the subprocess
+handle, it should reach for it deliberately rather than through a public property that exists for
+its benefit.
+
+**Rejected: merge `TargetProcess` into the session.** They are different lifetimes. A session
+exists before there is a process and after it exits; a target is a pid that currently exists and
+is what the monitor holds. Collapsing them is what produced the attach adapter's double role.
+
+**Rejected: rename only, and leave the shapes alone.** The names are the smaller half. A reader's
+actual difficulty is that `start()` returns `self` on one path and a different object on the
+other, and no name fixes that.
+
+**Open, to settle when picked up:** whether the session's `wait` keeps its `timeout` parameter.
+Its one caller passes 2.0 seconds with a comment explaining why, and the attach adapter ignores
+it entirely. Settled by whether the monitoring entry point still needs a bounded wait after
+[0038](0038-let-the-monitor-own-the-pid-lifecycle.md) reorganizes shutdown.
+
+## 5. Seams and testing decisions
+
+- **Seam:** `tests/monitoring/test_monitoring_base.py`, at the monitoring entry point — the
+  highest seam that can observe the change, because what these types are *for* is being handed to
+  that function and started. `tests/test_child_process_runner.py` and
+  `tests/monitoring/test_monitor_cmd.py` cover the two adapters at their own level.
+- **New seam needed:** none.
+- **What makes a good test here:** exercise both adapters through the same entry point and assert
+  the observable difference is only the one that should exist — the exit code. A test asserting
+  that a class implements a protocol proves the type checker ran; assert behaviour instead.
+- **Prior art:** `tests/monitoring/test_monitoring_base.py` for driving the entry point with a
+  substituted session; `tests/monitoring/conftest.py` for the existing fakes;
+  `tests/test_child_process_runner.py` for the spawn adapter's lifecycle.
+- **Cases:**
+  1. `gcmon run` propagates a failing script's exit code, as today.
+  2. `gcmon monitor <pid>` exits 0 whatever the attached process does, as today — the property
+     §1 says is undocumented, pinned by a test so that documenting it does not change it.
+  3. Both adapters satisfy the session interface with the same shape: `start()` returns a target
+     that is not the session itself.
+  4. Regression guard: the full suite passes; only imports, names and the trimmed members change.
+
+## 6. Out of scope
+
+- How a target is discovered or spawned. The subprocess construction, the environment injection
+  and the termination escalation are untouched.
+- The termination utilities, which are already a separate module with one job.
+- [0038](0038-let-the-monitor-own-the-pid-lifecycle.md)'s reorganization of the monitor and the
+  loop. This spec touches what is handed *to* the monitoring entry point; that one touches what
+  happens inside the loop. Independent, either order.
+- Adding a third way to name a target, such as attaching by process name.
+- The control address itself, which stays the one argument the session factory takes.
+
+## 7. Further notes
+
+This is the smallest spec in the set and the one most likely to be objected to as churn. The
+argument for it is §4.3: two adapters at one seam that do not have the same shape is not a naming
+problem, and the naming is what makes it hard to see. If only one of the five items is taken,
+take that one.

--- a/specs/0043-report-one-version-from-one-source.md
+++ b/specs/0043-report-one-version-from-one-source.md
@@ -1,0 +1,144 @@
+# 0043 — Report one version, from one source
+
+- **Status:** Not started
+- **Kind:** bug — reporting
+- **Effort:** XS
+- **Origin:** noticed while installing gcmon into a 3.15 venv, 2026-08-16
+- **Respects:** [ADR-0001](../docs/adr/0001-hand-rolled-perfetto-protobuf-encoder.md) (gcmon
+  adds a dependency only when it has to) — no ADR covers versioning
+
+## 1. Problem
+
+`gcmon.__version__` reports `0.1.0`. The distribution is `0.5.0`: the literal was last correct
+at `0.1.0`, and gcmon has released five times since — `0.2.0`, `0.3.0`, `0.3.1`, `0.4.0`,
+`0.5.0`. Anyone who imports gcmon to record which version produced a capture, or who quotes
+`gcmon.__version__` in a bug report, gets a number that was last correct before any of the
+current trace format existed — the loss track, the `Processes` track, RSS sampling and the
+Perfetto backend all landed after `0.1.0`. `importlib.metadata.version("gcmon")` on the same
+installed package answers `0.5.0`, so the two disagree inside one interpreter.
+
+There is no way for an operator to notice from the command line, because there is no way for an
+operator to *ask*: `gcmon` has no `--version` flag.
+
+## 2. Evidence
+
+Two version strings, one maintained and one not:
+
+- `gcmon.__version__` — a literal in the package's `__init__`, exported in its `__all__`,
+  `"0.1.0"`.
+- `[tool.poetry] version` in `pyproject.toml` — `"0.5.0"`, which is what the wheel carries and
+  what `importlib.metadata` reports.
+
+Nothing reads `__version__`. A search across `src/`, `tests/` and `.github/` returns its
+definition and its `__all__` entry, and nothing else — no CLI flag, no trace annotation, no
+pyperf metadata key, no test. That is why five releases went by without anyone noticing.
+
+Nothing checks it either. `.github/scripts/extract_changelog.py` reads
+`pyproject.toml["tool"]["poetry"]["version"]` and requires a matching `## Version X.Y.Z` header
+in `CHANGELOG.md`, so the release does verify that two of the three strings agree. `__init__` is
+not one of them.
+
+The release checklist in [docs/RELEASE.md](../docs/RELEASE.md) says "Bump `version` in
+`pyproject.toml`" — one instruction, naming one of the two places a version lives. The checklist
+is not a contributing factor to the drift; it *is* the drift, written down.
+
+## 3. Scope
+
+**Affected:** `gcmon.__version__`, on every install and every platform, since `0.2.0`.
+
+**Not affected:** the built distribution's metadata, PyPI, the git tags, the GitHub Release
+bodies, and the changelog — all four derive from `pyproject.toml` and are correct. Nothing in a
+trace carries a gcmon version today, so no capture is mislabelled. `pip show gcmon` is right.
+
+**Why the suite didn't catch it:** no test imports `__version__`. There was nothing to catch it
+with, and no consumer whose output would have looked wrong.
+
+## 4. Proposed change
+
+1. **Delete the literal and derive `__version__` from the installed metadata**, so the
+   duplication is gone rather than guarded:
+
+   ```python
+   try:
+       __version__ = importlib.metadata.version("gcmon")
+   except importlib.metadata.PackageNotFoundError:
+       __version__ = "0.0.0+unknown"   # a source tree with no install
+   ```
+
+   `pyproject.toml` becomes the single source. It is the right one: the versioning policy in
+   RELEASE.md already makes it authoritative by requiring the tag to match it exactly.
+
+2. **Add `gcmon --version`**, printing the same string. This is the reason the defect survived
+   five releases — the number was unobservable from outside — and it is what lets the fix be
+   tested at the CLI rather than by asserting a module attribute against itself.
+
+3. **Update [docs/RELEASE.md](../docs/RELEASE.md).** The checklist's first item stays one step,
+   and gains a clause saying `gcmon.__version__` follows from it with nothing to bump. Add a
+   line to the Versioning policy section stating that `pyproject.toml` is the single source and
+   that the package attribute is derived — the fact a future contributor needs before they
+   consider adding a second literal back.
+
+4. **Bump nothing.** This ships in whatever release it lands in; `0.1.0` was never a version of
+   this code and there is no history to preserve.
+
+**Rejected: keep the literal and have the release workflow check it matches**, alongside the
+changelog check it already runs. It is cheaper and it is the shape the repo already has, but it
+leaves two strings and adds a third thing to the release path to keep them equal. Deriving one
+from the other removes the failure mode instead of detecting it.
+
+**Rejected: make `pyproject.toml` read the version out of the package.** Poetry needs a plugin
+for a dynamic version, which is a build-time dependency for a two-line problem.
+
+**Accepted cost — a stale editable install reports the old number.** Bump `pyproject.toml` in a
+dev tree without reinstalling and `__version__` reports what the metadata still says. That is
+the same answer `pip show` gives and it is honest about what is installed; the alternative is a
+literal that is wrong for everyone rather than briefly stale for one developer. Say so in
+RELEASE.md.
+
+**Accepted cost — the `0.0.0+unknown` fallback.** RELEASE.md's versioning policy forbids
+`+local` suffixes on a *release*; this is the string for something that is not a release and
+cannot be one. It only appears when gcmon is imported from a checkout with no install at all.
+
+## 5. Seams and testing decisions
+
+- **Seam:** `tests/test_cli.py`, through `gcmon --version` — the highest seam available once
+  step 2 exists, and the reason to do step 2. Without it the only seam is the module attribute,
+  and a test that compares `__version__` to `importlib.metadata.version("gcmon")` is comparing
+  the implementation to itself.
+- **New seam needed:** none. `--version` is a new flag on an existing parser, covered by the
+  existing CLI tests.
+- **What makes a good test here:** assert the CLI's output equals the *installed distribution's*
+  version, read independently. Do **not** hardcode `0.5.0` — the test would then need editing
+  at every release, which is one more thing to forget and the same class of mistake as the
+  original. Do not assert against `gcmon.__version__` either; that is the value under test.
+- **Prior art:** `tests/test_cli.py` for driving `main()` and capturing output;
+  `tests/test_extract_changelog.py`, which is the existing test for the other half of the
+  version machinery and reads `pyproject.toml` rather than hardcoding a number.
+- **Cases:**
+  1. `gcmon --version` prints the installed distribution's version and exits 0.
+  2. `gcmon.__version__` equals it.
+  3. The fallback does not fire under a normal install — `__version__` is not
+     `0.0.0+unknown` when the tests run.
+  4. Regression guard: `python .github/scripts/extract_changelog.py` still resolves the version
+     from `pyproject.toml` and finds its changelog section. This change must not touch the
+     release path's own version resolution.
+
+## 6. Out of scope
+
+- Recording gcmon's own version in a trace. It is the natural next consumer and
+  [0020](0020-process-metadata-in-perfetto-traces.md) owns the mechanism — that spec adds the
+  *target's* Python version and GC thresholds as process-track annotations, and gcmon's version
+  belongs beside them, as one more annotation and one more decision about what a trace claims.
+  Fixing the number first is what makes that worth doing.
+- Reporting a version in the pyperf hook's metadata.
+- Any change to the release workflow, the tag format, or the changelog format.
+- The versioning policy itself. SemVer stays SemVer; this spec documents where the number lives,
+  not what it means.
+- Whether `0.1.0` should have been `0.5.0` in any published artifact. Nothing published is
+  wrong — the drift never left the source tree.
+
+## 7. Further notes
+
+Worth doing early despite being XS: every spec in the 0035–0042 set moves code, and a release
+cut in the middle of that work is the first time in five releases that someone is likely to look
+at `__version__` and believe it.

--- a/specs/README.md
+++ b/specs/README.md
@@ -18,23 +18,49 @@ spec here contradicts an ADR, one of the two is wrong and it is usually the spec
 | [0026](0026-one-process-name-across-live-and-offline-paths.md) | Bug — correctness | XS | A live capture names a process `Process 12345`; the same process combined from JSONL is named `12345` |
 | [0027](0027-thread-descriptor-tid-for-interpreter-zero.md) | Bug — reporting | XS | The main interpreter's `thread.tid` is the pid, so no SQL query reads interpreter ids uniformly |
 | [0028](0028-combined-exporter-reaches-into-sub-exporter-privates.md) | Feature — cleanup | XS | `chrome+perfetto` works only by reading a private attribute, with the type checkers told not to look |
-| [0029](0029-jsonl-and-stdout-duplicate-the-buffering.md) | Feature — cleanup | M | `JsonlExporter` carries three byte-identical copies of the buffer-and-flush logic; the next record type adds a fourth |
+| [0029](0029-jsonl-and-stdout-duplicate-the-buffering.md) | **Superseded** | M | Three byte-identical copies of the buffer-and-flush logic in `JsonlExporter`. 0036 removes them by collapsing the interface that produced them; §4's JSONL-schema argument still stands |
 | [0030](0030-exporter-hygiene-batch.md) | Feature — cleanup | S | Six one-file hazards in the exporter package: rank dict, `getattr` probe, builtin shadow, two undocumented threading contracts, duplicated validation |
 | [0031](0031-readme-output-example-is-labelled-chrome-only.md) | Bug — cosmetic | XS | The README's only trace example is headed "Chrome Trace Output" and captioned as the Perfetto UI |
 | [0033](0033-loss-counter-track.md) | Feature — enhancement | S | The loss row shows where gcmon was blind but not how much was lost; a bar losing 1 record looks like one losing 40 |
 | [0034](0034-separate-interpreter-confirmation-from-loss-arithmetic.md) | **Superseded** | S | Loss spans reached back across a collection gcmon watched start. ADR-0015's rewrite moved the edge to the poll instant, which is later still |
+| [0035](0035-derive-every-gc-sub-phase-from-one-table.md) | Feature — cleanup | L | CPython's eight optional GC sub-phases are written out by hand in six places; adding the ninth means six edits and nothing fails if one is missed |
+| [0036](0036-one-exporter-method-per-record-kind.md) | Feature — cleanup | M | `EventsExporter` has grown one method per record kind, three of them no-ops, and the CLI keeps a hand-maintained list of which formats really handle RSS |
+| [0037](0037-one-meta-emission-path-for-live-and-combined-traces.md) | Feature — cleanup | M | Two implementations of "emit this pid's process and thread meta"; 0026 exists because they already drifted once |
+| [0038](0038-let-the-monitor-own-the-pid-lifecycle.md) | Feature — cleanup | M | Per-pid state has two owners and is pruned twice against the same set; if they ever disagree a recycled pid reports a loss window that never happened |
+| [0039](0039-split-the-record-model-and-stats-by-concern.md) | Feature — cleanup | S | The record model and the stats module carry three jobs each; `tests/stats/` is already split along a seam the source does not have |
+| [0040](0040-derive-the-monitoring-options-from-one-table.md) | Feature — cleanup | M | Every monitoring option is declared three times, and a rejected configuration is echoed to the log as though it had been accepted |
+| [0041](0041-give-the-package-explicit-layers.md) | Feature — cleanup | L | The package's five layers are invisible and unchecked; the dependency direction is clean today and nothing keeps it that way |
+| [0042](0042-name-the-process-session-for-its-role.md) | Feature — cleanup | S | The monitored-process seam is named for a role it does not fill, and its two adapters do not have the same shape |
+| [0043](0043-report-one-version-from-one-source.md) | Bug — reporting | XS | `gcmon.__version__` says `0.1.0` against a `0.5.0` distribution; nothing reads it, nothing checks it, and there is no `--version` to ask |
 
 **Suggested order:** 0025 (the only outage, and it is one word) → 0026 (smallest user-visible
-wrongness) → 0028 (XS, and it shrinks 0029) → 0027 (needs a trace-processor answer before it
-can be settled either way) → 0031 → 0030 → 0029 → 0020. 0024 is the owner's to file and
-depends on nothing here.
+wrongness) → 0043 (XS, and everything below it makes a release more likely, which is when a
+wrong version gets believed) → 0028 (XS, and it shrinks 0036) → 0027 (needs a trace-processor
+answer before it can be settled either way) → 0031 → 0030 → 0035 → 0037 → 0036 → 0039 → 0040 →
+0038 → 0042 → 0020 → 0041. 0024 is the owner's to file and depends on nothing here.
+
+Four ordering constraints inside that run, and only four: 0026 before 0037, which assumes its
+shared naming helper; 0028 before 0036, which it shrinks; 0035 before 0039, which would
+otherwise move nine classes 0035 deletes; and 0039 before 0041, or the same files move twice.
+0038, 0040 and 0042 are independent of everything and can be taken whenever there is an
+appetite for them. 0041 is last on purpose — see its §7, which argues against doing it between
+two changes that actually move code.
 
 0033 came out of the work that landed as ADR-0015 and blocks nothing; it wants a real capture in
 front of you before it can be judged worth a fourth row. 0034 came from the same session and is
 superseded: ADR-0015's rewrite took the span's left edge from the poll clock, which is later than
 the bound 0034 set out to restore. Its §4 still carries the argument for why a temporal bound
 differs from the clipping ADR-0015 rejected, worth reading before anyone proposes narrowing a
-span.
+span. 0029 is superseded by 0036 for the same reason and on the same terms: its §4 is still the
+fullest statement of why the JSONL schema is load-bearing, and 0036 summarizes rather than
+replaces it.
+
+0035–0042 came out of a code-structure review of `src/gcmon` on 2026-08-15. Three findings from
+that review are not in the table because they were already spec'd: the combined exporter's reach
+into a private attribute (0028), the JSONL buffering duplication (0029), and the duplicated
+`combine` format validation (0030 §4.5). 0043 came from installing the package into a clean
+3.15 environment the next day, which is the first thing in five releases to put the built
+distribution's version next to the package's own.
 
 ## Templates
 


### PR DESCRIPTION
Nine forward-looking specs from a structure review of `src/gcmon`. No source changes — `git diff main..HEAD -- src/` is empty.

| Spec | Kind | Effort | What |
|---|---|---|---|
| 0035 | cleanup | L | Derive the eight optional GC sub-phases from one table instead of six hand-written copies |
| 0036 | cleanup | M | One exporter method per record kind; supersedes 0029 |
| 0037 | cleanup | M | One meta-emission path for live and combined traces |
| 0038 | cleanup | M | Move the pid lifecycle wholly into the monitor |
| 0039 | cleanup | S | Split the record model and stats by concern |
| 0040 | cleanup | M | Derive the monitoring options from one table; validate before echoing |
| 0041 | cleanup | L | Make the package layers explicit, with an import-direction test |
| 0042 | cleanup | S | Name the process-session seam for its role |
| 0043 | bug — reporting | XS | `gcmon.__version__` is `0.1.0` against a `0.5.0` distribution |

### Relationship to existing specs

- **0029 is marked Superseded** by 0036, following the precedent 0034 set. Not deleted: its §4 is still the fullest statement of why the JSONL schema is load-bearing, and 0036 summarizes rather than replaces it.
- Three review findings are **not** here because they were already spec'd — the combined exporter's private-attribute reach (0028), the JSONL buffering duplication (0029), and the duplicated `combine` format validation (0030 §4.5).
- 0037 takes up what 0026 explicitly left out of scope.

### ADR interactions

Flagged in each spec's header rather than left implicit:

- 0035 and 0037 **extend** ADR-0007 to consumers it never reached.
- 0038 **moves a name ADR-0011 anchors on** (liveness reporting) and amends the record with it, per the ADR README's rule.
- 0039 amends the implementation notes in ADR-0009 and ADR-0015, which name modules that move.
- 0037 **declines** the larger change that would contradict ADR-0008's "the encoder runs without an exporter", and names the condition that would reopen it.
- 0041 quantifies its own documentation cost: 62 lines across 14 ADRs and the prose docs name `src/gcmon/…` paths, all amendments in that change.

### Ordering

`specs/README.md` carries the revised suggested order and the four real constraints: 0026 before 0037, 0028 before 0036, 0035 before 0039, 0039 before 0041. Everything else is independent. 0041 is last on purpose — its §7 argues against doing it between two changes that actually move code.

### Verified rather than asserted

Run under Python 3.15.0b4 in a fresh venv:

- Full suite green: 1564 passed, 6 skipped, 60 deselected, 2 xfailed (`--ignore=tests/benchmarks`, which needs `pytest-codspeed`).
- 0041's central claim re-checked against the source: 54 files parsed, **zero** upward imports. The layering already holds; the test locks it in.
- Every prior-art test file and symbol cited across the nine specs resolves, `TestMetaDedupRaceClosed` included.