### PR TITLE
Rename lifetime totals to CumulativeCounters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,5 +41,9 @@ examples/
 # Anchored: `.github/scripts` is tracked.
 /scripts/
 
+# Local trace and capture artifacts. Anchored so a future `output/` inside the
+# package is not swept up with them.
+/output/
+
 # Local issue tracker (see docs/agents/issue-tracker.md)
 .scratch/

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -79,7 +79,10 @@ _Avoid_: true, real, total
 **Lifetime totals**:
 Everything one interpreter has collected since it started, monitored window
 included. Always written with the qualifier: bare **lifetime** means the
-`Processes`-track span above.
+`Processes`-track span above. The source names the counters underneath rather
+than the interval — `CumulativeCounters`, `StreamingStats.observe_cumulative`,
+`cumulative_totals_by_gen` — so the bare word is left to the span everywhere
+outside this prose and the `pause_gen_N_lifetime_*` pyperf keys.
 _Avoid_: lifetime (bare), cumulative total (the counters underneath are
 cumulative, the interval is not), since-start count
 

--- a/specs/0039-split-the-record-model-and-stats-by-concern.md
+++ b/specs/0039-split-the-record-model-and-stats-by-concern.md
@@ -68,9 +68,9 @@ consumer, not about gcmon's data.
 
 **4.2 — `stats` becomes a package with three modules**, matching `tests/stats/`: the
 accumulator (`Stats`, `get_quantile_value`, the DDSketch fallback), the metric table, and the
-streaming aggregation (`StreamingStats`, `LossTotals`, `PauseTotals`, `LifetimeTotals` and the
-two key aliases). `stats_output` stays where it is — it is presentation and it already has one
-job.
+streaming aggregation (`StreamingStats`, `LossTotals`, `PauseTotals`, `CumulativeCounters` and
+the two key aliases). `stats_output` stays where it is — it is presentation and it already has
+one job.
 
 **4.3 — The metric table is whatever [0035](0035-derive-every-gc-sub-phase-from-one-table.md)
 leaves.** If 0035 has landed, this module is the derivation from the phase table and is a few

--- a/src/gcmon/monitor.py
+++ b/src/gcmon/monitor.py
@@ -144,7 +144,7 @@ class EventsMonitor:
 
             gen_loss = accumulator.ingest(unseen)
             gens_by_iid.setdefault(iid, []).append(gen_loss)
-            self._stats.record_lifetime(pid, iid, gen, accumulator.last_collections, accumulator.last_duration)
+            self._stats.observe_cumulative(pid, iid, gen, accumulator.last_collections, accumulator.last_duration)
             if gen_loss.lost_count:
                 self._stats.record_loss(pid, iid, gen, gen_loss.lost_count, gen_loss.lost_pause_ns)
             fresh.extend(unseen)

--- a/src/gcmon/pyperf/hook.py
+++ b/src/gcmon/pyperf/hook.py
@@ -71,11 +71,11 @@ def _get_env_pyperf_hook_output(bench_name: str, pid: int) -> Path:
 def _replay(stats: StreamingStats, parsed: Mapping[int, Sequence[TItem]]) -> None:
     """Rebuild a session's statistics from the records it wrote.
 
-    The monitor folds loss and lifetime as it polls, but the hook meets the
-    session only as a file, so both have to come back off it. Loss rides in
-    records of its own. Lifetime rides on every GC record, whose
-    ``collections`` and ``duration`` are the target's cumulative totals, so
-    the newest record of each ring carries what the monitor recorded live.
+    The monitor folds loss and the cumulative counters as it polls, but the
+    hook meets the session only as a file, so both have to come back off it.
+    Loss rides in records of its own. The counters ride on every GC record,
+    whose ``collections`` and ``duration`` are the target's cumulative totals,
+    so the newest record of each ring carries what the monitor observed live.
 
     Loss is summed per ``(pid, iid, gen)`` before it goes in: one record covers
     one interpreter's poll interval and names every generation active in it, so
@@ -102,7 +102,7 @@ def _replay(stats: StreamingStats, parsed: Mapping[int, Sequence[TItem]]) -> Non
                     lost[ring] = (seen_count + entry.lost_count, seen_pause + entry.lost_pause_ns)
 
     for (pid, iid, gen), record in newest.items():
-        stats.record_lifetime(pid, iid, gen, record.collections, record.duration)
+        stats.observe_cumulative(pid, iid, gen, record.collections, record.duration)
 
     for (pid, iid, gen), (count, pause_ns) in lost.items():
         if count or pause_ns:

--- a/src/gcmon/pyperf/metrics.py
+++ b/src/gcmon/pyperf/metrics.py
@@ -51,7 +51,7 @@ def to_metrics(stats: StreamingStats) -> dict[str, int | float]:
     """
     result: dict[str, int | float] = {}
     pauses = stats.pause_totals_by_gen()
-    lifetimes = stats.lifetime_totals_by_gen()
+    cumulative = stats.cumulative_totals_by_gen()
     pause_stats = stats.metrics["pause"]
     exact_total = 0
     for gen in stats.GENS:
@@ -68,10 +68,13 @@ def to_metrics(stats: StreamingStats) -> dict[str, int | float]:
             result[keys.count] = exact_count
             # A sampled count above zero is why this needs no zero guard.
             result[keys.coverage] = sampled_count / exact_count
-        lifetime = lifetimes.get(gen)
-        if lifetime is not None and lifetime.collections > 0:
-            result[keys.lifetime_count] = lifetime.collections
-            result[keys.lifetime_sum] = dur_to_ms(lifetime.pause_ns)
+        # The `lifetime` in the key names is the wire vocabulary pyperf
+        # publishes and reads as "since start"; the counters behind it are
+        # `CumulativeCounters`.
+        counters = cumulative.get(gen)
+        if counters is not None and counters.collections > 0:
+            result[keys.lifetime_count] = counters.collections
+            result[keys.lifetime_sum] = dur_to_ms(counters.pause_ns)
     heap_p99 = stats.heap_size_p99()
     if heap_p99 is not None:
         result["heap_size_p99"] = heap_p99

--- a/src/gcmon/stats.py
+++ b/src/gcmon/stats.py
@@ -314,8 +314,9 @@ class PauseTotals(msgspec.Struct, frozen=True, gc=False):
         return (sampled + self.lost_pause_ns) / sampled
 
 
-class LifetimeTotals(msgspec.Struct):
-    """One ring's own cumulative counters, as the target keeps them.
+class CumulativeCounters(msgspec.Struct):
+    """One ring's counters, counted as the target counts them: from the moment
+    its interpreter started, not from the moment gcmon attached.
 
     A poll overwrites the slot, and a fold sums slots into a fresh one. Both
     reads return that fresh one, never a slot, so this side needs no
@@ -346,7 +347,7 @@ class RingStats(msgspec.Struct):
 
     `metrics` is ``None`` until the ring is admitted, and stays ``None`` if
     the bound declined it. The bound caps sample buffers alone: they hold a
-    thousand values per generation per metric, where `loss` and `lifetime`
+    thousand values per generation per metric, where `loss` and `cumulative`
     hold two numbers per generation each. A declined ring goes on counting,
     so the run totals and the coverage figures stay whole.
 
@@ -357,7 +358,7 @@ class RingStats(msgspec.Struct):
     metrics: TStatsData | None = None
     declined: bool = False
     loss: dict[int, LossTotals] = msgspec.field(default_factory=dict)
-    lifetime: dict[int, LifetimeTotals] = msgspec.field(default_factory=dict)
+    cumulative: dict[int, CumulativeCounters] = msgspec.field(default_factory=dict)
 
     def settle(self) -> None:
         """Fix the percentiles and give the sample buffers back."""
@@ -449,7 +450,7 @@ class StreamingStats:
     def _open_ring(self, pid: int, iid: int) -> RingStats:
         """The ring the records arriving now belong to, opened if new.
 
-        Every ring gets one, since loss and lifetime totals are due from a
+        Every ring gets one, since loss and cumulative totals are due from a
         ring the bound turned away as much as from one it admitted.
         """
         key = (pid, iid)
@@ -588,16 +589,18 @@ class StreamingStats:
                     worst = (iid, gen, coverage)
         return worst
 
-    def record_lifetime(self, pid: int, iid: int, gen: int, collections: int, duration_s: float) -> None:
-        """Record one ring's totals since its interpreter started.
+    def observe_cumulative(self, pid: int, iid: int, gen: int, collections: int, duration_s: float) -> None:
+        """Take one ring's totals since its interpreter started.
 
         The target counts both of them cumulatively, so the newest values
-        replace the previous ones. A successor on a reused pid writes into an
-        entry of its own, so the fold adds the two rather than losing the
-        larger history to the smaller one that follows it.
+        replace the previous ones — this observes a counter rather than
+        appending to one, which is what separates it from `record_loss`. A
+        successor on a reused pid writes into an entry of its own, so the fold
+        adds the two rather than losing the larger history to the smaller one
+        that follows it.
         """
         self._open_pid(pid)
-        self._open_ring(pid, iid).lifetime[gen] = LifetimeTotals(collections, duration_s)
+        self._open_ring(pid, iid).cumulative[gen] = CumulativeCounters(collections, duration_s)
 
     def pause_totals(self, pid: int, iid: int, gen: int, pid_epoch: int | None = None) -> PauseTotals:
         """One ring, read once.
@@ -636,8 +639,8 @@ class StreamingStats:
             )
         return by_gen
 
-    def lifetime_scope(self) -> tuple[int, int]:
-        """How many interpreters, in how many processes, the lifetime fold
+    def cumulative_scope(self) -> tuple[int, int]:
+        """How many interpreters, in how many processes, the cumulative fold
         covers.
 
         A caller states both alongside the fold, so a reader can tell one
@@ -648,16 +651,17 @@ class StreamingStats:
         them apart. A pid gcmon never saw exit still counts as one.
         """
         interpreters = {
-            key for key, ring in self._keyed_rings() if any(totals.collections for totals in ring.lifetime.values())
+            key for key, ring in self._keyed_rings() if any(totals.collections for totals in ring.cumulative.values())
         }
         return len(interpreters), len({(pid, pid_epoch) for pid, _iid, pid_epoch in interpreters})
 
-    def lifetime_totals_by_gen(self) -> dict[int, LifetimeTotals]:
-        """Fold every ring's lifetime totals into a per-gen one, single pass."""
-        by_gen: dict[int, LifetimeTotals] = {}
+    def cumulative_totals_by_gen(self) -> dict[int, CumulativeCounters]:
+        """Fold every ring's cumulative counters into a per-gen total, single
+        pass."""
+        by_gen: dict[int, CumulativeCounters] = {}
         for ring in self._all_rings():
-            for gen, totals in ring.lifetime.items():
-                by_gen.setdefault(gen, LifetimeTotals()).add(totals.collections, totals.duration_s)
+            for gen, totals in ring.cumulative.items():
+                by_gen.setdefault(gen, CumulativeCounters()).add(totals.collections, totals.duration_s)
         return by_gen
 
     @property

--- a/src/gcmon/stats_output.py
+++ b/src/gcmon/stats_output.py
@@ -249,26 +249,26 @@ def _print_footer(stats: StreamingStats) -> None:
     reads ``1.``.
     """
     pauses = stats.pause_totals_by_gen()
-    lifetimes = stats.lifetime_totals_by_gen()
+    cumulative = stats.cumulative_totals_by_gen()
     covered = [(gen, pauses[gen]) for gen in stats.GENS if pauses[gen].lost_count]
-    lifetime = [(gen, lifetimes[gen]) for gen in stats.GENS if gen in lifetimes and lifetimes[gen].collections]
+    counted = [(gen, cumulative[gen]) for gen in stats.GENS if gen in cumulative and cumulative[gen].collections]
 
     notes: list[str] = []
     if covered:
         parts = ", ".join(f"Gen{gen} {_coverage_cell(t.coverage, t.lost_count)}" for gen, t in covered)
         notes.append(f"Coverage: {parts}. Count and Sum read sampled/exact; percentiles are sampled and read high.")
-    if lifetime:
+    if counted:
         parts = ", ".join(
-            f"Gen{gen} {totals.collections} in {dur_to_ms(totals.pause_ns):.3f} ms" for gen, totals in lifetime
+            f"Gen{gen} {totals.collections} in {dur_to_ms(totals.pause_ns):.3f} ms" for gen, totals in counted
         )
-        interpreters, processes = stats.lifetime_scope()
+        interpreters, processes = stats.cumulative_scope()
         # One line per generation whatever the size of the tree. The counts
         # say what it summed over: interpreters start at different moments,
         # and a reused pid folds two processes into one figure.
         #
         # "monitored window included" covers that window rather than
         # excluding it, so the note must not read as a figure to add to
-        # `Count`. `lifetime_count` is the target's own cumulative counter.
+        # `Count`. It reports the target's own cumulative counter.
         notes.append(
             f"Since each interpreter started, monitored window included, summed over "
             f"{_plural(interpreters, 'interpreter')} in {_plural(processes, 'process', 'processes')}: {parts}."

--- a/tests/pyperf/test_metrics.py
+++ b/tests/pyperf/test_metrics.py
@@ -104,7 +104,7 @@ class TestMetricsAreExact:
 
         assert "pause_gen_0_lifetime_count" not in to_metrics(stats)
 
-        stats.record_lifetime(1, 0, 0, 5_000, 5.0)
+        stats.observe_cumulative(1, 0, 0, 5_000, 5.0)
 
         assert to_metrics(stats)["pause_gen_0_lifetime_count"] == 5_000
 

--- a/tests/pyperf/test_pyperf_hook.py
+++ b/tests/pyperf/test_pyperf_hook.py
@@ -419,13 +419,13 @@ class TestGCMonitorHookTeardown:
         assert not temp_file_1.exists()
 
 
-class TestTeardownReplaysLossAndLifetime:
+class TestTeardownReplaysLossAndCumulativeCounters:
     """What the monitor folded live has to come back off the file.
 
     The hook meets a session only as JSONL, so a loss record it skips is a
     session that publishes full coverage and a sampled sum labelled exact.
-    Lifetime needs no record of its own: ``collections`` and ``duration`` on
-    every GC record are the target's own cumulative totals.
+    The cumulative counters need no record of their own: ``collections`` and
+    ``duration`` on every GC record are the target's own cumulative totals.
     """
 
     LOST = _make_jsonl_loss(lost_count=2, lost_pause_ns=7_000_000)
@@ -470,14 +470,16 @@ class TestTeardownReplaysLossAndLifetime:
         assert metadata["gc_pause_gen_0_count"] == 2
         assert metadata["gc_pause_gen_0_sum"] == pytest.approx(10.0)
 
-    def test_lifetime_comes_from_the_newest_record_of_the_ring(self, tmp_path: Path, mock_env_output: None) -> None:
+    def test_the_counters_come_from_the_newest_record_of_the_ring(self, tmp_path: Path, mock_env_output: None) -> None:
         """The whole history the target reports, not the monitored part."""
         metadata = self.metadata(tmp_path, *self.observed(), self.LOST)
 
         assert metadata["gc_pause_gen_0_lifetime_count"] == 8
         assert metadata["gc_pause_gen_0_lifetime_sum"] == pytest.approx(20.0)
 
-    def test_records_out_of_order_do_not_walk_lifetime_backwards(self, tmp_path: Path, mock_env_output: None) -> None:
+    def test_records_out_of_order_do_not_walk_the_counters_backwards(
+        self, tmp_path: Path, mock_env_output: None
+    ) -> None:
         """Cumulative totals only ever grow, so the highest counter wins
         however the lines happen to be ordered."""
         newest, oldest = self.observed()[1], self.observed()[0]

--- a/tests/stats/test_stats.py
+++ b/tests/stats/test_stats.py
@@ -344,18 +344,18 @@ class TestTotalsLeaveTheAccumulatorBehind:
         assert stats.pause_totals(1, 0, 0).lost_count == 7
         assert stats.pause_totals(1, 0, 0).lost_pause_ns == 7_000
 
-    def test_lifetime_reads_hand_back_scratch(self) -> None:
-        """`LifetimeTotals` is the accumulator a fold adds into, so this side
+    def test_cumulative_reads_hand_back_scratch(self) -> None:
+        """`CumulativeCounters` is the accumulator a fold adds into, so this side
         cannot be frozen the way the pause side is. The fold still sums into
         a fresh one, which is what the write below lands on."""
         stats = StreamingStats()
-        stats.record_lifetime(1, 0, 0, 40, 4.0)
-        stats.record_lifetime(1, 1, 0, 2, 0.5)
+        stats.observe_cumulative(1, 0, 0, 40, 4.0)
+        stats.observe_cumulative(1, 1, 0, 2, 0.5)
 
-        stats.lifetime_totals_by_gen()[0].add(99, 9.0)
+        stats.cumulative_totals_by_gen()[0].add(99, 9.0)
 
-        assert stats.lifetime_totals_by_gen()[0].collections == 42
-        assert stats.lifetime_totals_by_gen()[0].pause_ns == 4_500_000_000
+        assert stats.cumulative_totals_by_gen()[0].collections == 42
+        assert stats.cumulative_totals_by_gen()[0].pause_ns == 4_500_000_000
 
 
 class TestLowCoverage:
@@ -469,32 +469,32 @@ class TestLowCoverage:
         assert stats.low_coverage(1) == first
 
 
-class TestLifetimeTotals:
+class TestCumulativeCounters:
     def test_summed_across_interpreters(self) -> None:
         stats = StreamingStats()
-        stats.record_lifetime(1, 0, 0, 500, 0.5)
-        stats.record_lifetime(1, 1, 0, 300, 0.3)
+        stats.observe_cumulative(1, 0, 0, 500, 0.5)
+        stats.observe_cumulative(1, 1, 0, 300, 0.3)
 
-        assert stats.lifetime_totals_by_gen()[0].collections == 800
-        assert stats.lifetime_totals_by_gen()[0].pause_ns == 800_000_000
+        assert stats.cumulative_totals_by_gen()[0].collections == 800
+        assert stats.cumulative_totals_by_gen()[0].pause_ns == 800_000_000
 
     def test_the_newest_value_replaces_the_last(self) -> None:
         """Cumulative in the target, so polls report a running total, not a
         delta -- adding them would count every collection many times."""
         stats = StreamingStats()
-        stats.record_lifetime(1, 0, 0, 500, 0.5)
-        stats.record_lifetime(1, 0, 0, 900, 0.9)
+        stats.observe_cumulative(1, 0, 0, 500, 0.5)
+        stats.observe_cumulative(1, 0, 0, 900, 0.9)
 
-        assert stats.lifetime_totals_by_gen()[0].collections == 900
+        assert stats.cumulative_totals_by_gen()[0].collections == 900
 
     def test_it_can_exceed_the_observed_span(self) -> None:
         """The point of reporting it: what ran before gcmon attached is not
         loss, and must not touch `Cov`."""
         stats = StreamingStats()
         stats.update(1, create_mock_stats_item(gen=0, ts_start=0, ts_stop=1_000))
-        stats.record_lifetime(1, 0, 0, 5_000, 5.0)
+        stats.observe_cumulative(1, 0, 0, 5_000, 5.0)
 
-        assert stats.lifetime_totals_by_gen()[0].collections == 5_000
+        assert stats.cumulative_totals_by_gen()[0].collections == 5_000
         assert stats.pause_totals(1, 0, 0).exact_count == 1
         assert stats.pause_totals(1, 0, 0).coverage == 1.0
 
@@ -678,11 +678,11 @@ class TestTheBoundOnRunningRings:
 
         assert stats.pause_totals_by_gen()[0].lost_count == 99
 
-    def test_its_lifetime_still_reaches_the_note(self) -> None:
+    def test_its_cumulative_counters_still_reach_the_note(self) -> None:
         stats = self._full()
-        stats.record_lifetime(9_999, 0, 0, 400, 0.4)
+        stats.observe_cumulative(9_999, 0, 0, 400, 0.4)
 
-        assert stats.lifetime_totals_by_gen()[0].collections == 400
+        assert stats.cumulative_totals_by_gen()[0].collections == 400
 
     def test_a_successor_on_a_declined_pid_can_get_a_row(self) -> None:
         """The decline was made against the process that held the pid, and it
@@ -723,24 +723,24 @@ class TestADeathTheMonitorCalled:
         for _ in range(3):
             stats.update(1, create_mock_stats_item(gen=0, ts_start=0, ts_stop=1_000))
         stats.record_loss(1, 0, 0, 2, 2_000)
-        stats.record_lifetime(1, 0, 0, 300, 0.3)
+        stats.observe_cumulative(1, 0, 0, 300, 0.3)
 
         stats.materialize(1)
 
         for _ in range(2):
             stats.update(1, create_mock_stats_item(gen=0, ts_start=0, ts_stop=1_000))
         stats.record_loss(1, 0, 0, 1, 1_000)
-        stats.record_lifetime(1, 0, 0, 500, 0.5)
+        stats.observe_cumulative(1, 0, 0, 500, 0.5)
         return stats
 
-    def test_its_lifetime_starts_fresh(self) -> None:
+    def test_its_cumulative_counters_start_fresh(self) -> None:
         """The fold reads 800 over an interpreter that ran 500, and that is the
         decision rather than a slip. gcmon could tell the two apart here, since
         a real successor's counter restarts low, but only by deciding liveness
         a second way and disagreeing with the monitor whenever the two differ.
         ADR-0016 has the reasoning.
         """
-        assert self._called_dead_but_running().lifetime_totals_by_gen()[0].collections == 800
+        assert self._called_dead_but_running().cumulative_totals_by_gen()[0].collections == 800
 
 
 class TestAReusedPid:
@@ -760,14 +760,14 @@ class TestAReusedPid:
         for _ in range(8):
             stats.update(1, create_mock_stats_item(gen=0, ts_start=0, ts_stop=1_000))
         stats.record_loss(1, 0, 0, 2, 2_000)
-        stats.record_lifetime(1, 0, 0, 400, 0.4)
+        stats.observe_cumulative(1, 0, 0, 400, 0.4)
 
         stats.materialize(1)
 
         for _ in range(8):
             stats.update(1, create_mock_stats_item(gen=0, ts_start=0, ts_stop=9_000))
         stats.record_loss(1, 0, 0, 2, 18_000)
-        stats.record_lifetime(1, 0, 0, 10, 0.01)
+        stats.observe_cumulative(1, 0, 0, 10, 0.01)
         return stats
 
     def test_each_process_gets_a_block(self) -> None:
@@ -797,13 +797,13 @@ class TestAReusedPid:
         assert stats.pause_totals(1, 0, 0, 1).lost_pause_ns == 2_000
         assert stats.pause_totals(1, 0, 0, 2).lost_pause_ns == 18_000
 
-    def test_the_lifetime_fold_adds_them(self) -> None:
+    def test_the_cumulative_fold_adds_them(self) -> None:
         """The successor's counters are smaller and used to overwrite the
         predecessor's, so the folded total could fall mid-run."""
-        assert self._reused().lifetime_totals_by_gen()[0].collections == 410
+        assert self._reused().cumulative_totals_by_gen()[0].collections == 410
 
     def test_the_footnote_counts_two_processes(self) -> None:
-        assert self._reused().lifetime_scope() == (2, 2)
+        assert self._reused().cumulative_scope() == (2, 2)
 
     def test_neither_is_counted_as_untracked(self) -> None:
         assert self._reused().untracked_rings() == 0

--- a/tests/stats/test_stats_output.py
+++ b/tests/stats/test_stats_output.py
@@ -505,10 +505,12 @@ class TestLossColumns:
         assert "Coverage: Gen0 30.0%" in out
         assert "percentiles are sampled and read high" in out
 
-    def test_the_footer_separates_lifetime_from_the_session(self, capsys: pytest.CaptureFixture[str]) -> None:
+    def test_the_footer_separates_the_cumulative_counters_from_the_session(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
         """It is not loss and must not read as part of `Cov`."""
         stats = self._lossy()
-        stats.record_lifetime(1, 0, 0, 5_000, 5.0)
+        stats.observe_cumulative(1, 0, 0, 5_000, 5.0)
 
         print_stats(stats)
         out = capsys.readouterr().out
@@ -579,7 +581,7 @@ class TestTheFooterNotesAreNumbered:
         for _ in range(3):
             stats.update(1, create_mock_stats_item(gen=0, ts_start=0, ts_stop=1_000_000))
         stats.record_loss(1, 0, 0, 7, 7_000_000)
-        stats.record_lifetime(1, 0, 0, 18, 0.02)
+        stats.observe_cumulative(1, 0, 0, 18, 0.02)
 
         print_stats(stats)
         notes = self._notes(capsys.readouterr().out)
@@ -612,7 +614,7 @@ class TestTheFooterNotesAreNumbered:
         assert self._notes(capsys.readouterr().out) == []
 
 
-class TestTheLifetimeNoteNamesItsFold:
+class TestTheCumulativeNoteNamesItsFold:
     """One line per generation whatever the size of the tree, stating what it
     summed over: interpreters start at different moments, and a reused pid
     folds two processes into one figure.
@@ -630,7 +632,7 @@ class TestTheLifetimeNoteNamesItsFold:
         stats = StreamingStats()
         for pid, iid in rings:
             stats.update(pid, create_mock_stats_item(iid=iid, gen=0, ts_start=0, ts_stop=1_000_000))
-            stats.record_lifetime(pid, iid, 0, 500, 0.5)
+            stats.observe_cumulative(pid, iid, 0, 500, 0.5)
         return stats
 
     def test_the_counts_are_the_ones_it_summed(self, capsys: pytest.CaptureFixture[str]) -> None:
@@ -638,7 +640,7 @@ class TestTheLifetimeNoteNamesItsFold:
 
         print_stats(stats)
 
-        assert self._scope(capsys.readouterr().out) == stats.lifetime_scope() == (3, 2)
+        assert self._scope(capsys.readouterr().out) == stats.cumulative_scope() == (3, 2)
 
     def test_an_ordinary_run_reads_in_the_singular(self, capsys: pytest.CaptureFixture[str]) -> None:
         print_stats(self._stats([(1, 0)]))


### PR DESCRIPTION
`lifetime` named two unrelated things one directory apart: the ADR-0011 span on the `Processes` track, and the counters the target has run since its interpreter started. `CONTEXT.md` already reserved the bare word for the span — the source did not.

The counters now say what they are and how they combine:

| Before | After |
|---|---|
| `LifetimeTotals` | `CumulativeCounters` |
| `RingStats.lifetime` | `RingStats.cumulative` |
| `record_lifetime` | `observe_cumulative` |
| `lifetime_totals_by_gen` | `cumulative_totals_by_gen` |
| `lifetime_scope` | `cumulative_scope` |

`observe_` carries the point: the newest read replaces the slot, where the neighbouring `record_loss` genuinely appends. One type was playing overwritten-slot and running-sum with nothing in the name to separate them.
