### PR TITLE
Test the JSONL buffer flushing on loss and instant events

### DIFF
--- a/tests/exporters/test_jsonl_exporter.py
+++ b/tests/exporters/test_jsonl_exporter.py
@@ -195,6 +195,28 @@ class TestJsonlExporterFlushThreshold:
         exporter.add_event(DEFAULT_PID, mock_stats_item)
         assert len(read_jsonl(path)) == 2
 
+    def test_flush_on_threshold_reached_for_loss_events(
+        self, jsonl_exporter: ExporterFactory, read_jsonl: JsonlFileReader
+    ) -> None:
+        exporter, path = jsonl_exporter(threshold=5)
+        for _ in range(4):
+            exporter.add_loss_event(DEFAULT_PID, create_mock_loss_item())
+            if path.exists():
+                assert len(read_jsonl(path)) == 0
+        exporter.add_loss_event(DEFAULT_PID, create_mock_loss_item())
+        assert len(read_jsonl(path)) == 5
+
+    def test_flush_on_threshold_reached_for_instant_events(
+        self, jsonl_exporter: ExporterFactory, read_jsonl: JsonlFileReader
+    ) -> None:
+        exporter, path = jsonl_exporter(threshold=5)
+        for _ in range(4):
+            exporter.add_instant_event(DEFAULT_PID, create_instant_msg())
+            if path.exists():
+                assert len(read_jsonl(path)) == 0
+        exporter.add_instant_event(DEFAULT_PID, create_instant_msg())
+        assert len(read_jsonl(path)) == 5
+
 
 class TestJsonlExporterInstantEvents:
     def test_add_instant_event_json_output_format(


### PR DESCRIPTION
`JsonlExporter.add_event` has four tests for its threshold flush. The identical branch in `add_loss_event` and `add_instant_event` had none: both were covered only by an end-to-end monitor run that happened to buffer 100 events before closing, and the poll cadence from #109 stopped that from happening. Codecov read the loss as a project drop on that PR, on a file the PR never touched.

Two tests mirroring `test_flush_on_threshold_reached`, one per method: a threshold of 5, four events that must not flush, a fifth that must.

`src/gcmon/exporters/jsonl_exporter.py` goes from 5 misses and 3 partials back to 1 and 1. The one that remains is the `if not events: return` guard in `_flush`, which no caller reaches; it was uncovered on `main` before this too.