### PR TITLE
fix(cli): require a subcommand in the CLI parser (#143)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 
 ### Bugfixes
 
+- `gcmon` with no subcommand prints a usage message and exits 2, where it used to print an `AttributeError` traceback
 - An instant sent close to the end of a run reaches the trace, where the last one a client sent could be dropped without a word
 - A `Processes` slice names the program its own process was running. A reused PID used to put the first process's command line on every slice of that PID, and a process that exited before the first flush got none at all
 - A `Processes` slice covers only the process it names, where a reused PID used to draw one slice spanning both and the stretch between them

--- a/src/gcmon/cli/main.py
+++ b/src/gcmon/cli/main.py
@@ -13,8 +13,6 @@ from .commands import (
     add_run_parser,
 )
 
-logger = logging.getLogger("gcmon")
-
 
 class _VersionAction(argparse.Action):
     """Print gcmon's version and exit.
@@ -49,7 +47,7 @@ def _create_parser() -> argparse.ArgumentParser:
         dest=argparse.SUPPRESS,
         help="Print the installed gcmon version and exit",
     )
-    subparsers = parser.add_subparsers(dest="command", help="Available commands")
+    subparsers = parser.add_subparsers(dest="command", required=True, help="Available commands")
 
     add_monitor_parser(subparsers.add_parser)
     add_combine_parser(subparsers.add_parser)
@@ -141,16 +139,7 @@ def main(argv: list[str] | None = None) -> int:
     _setup_logging(args.verbose)
 
     # Dispatch via args.func (set by each subparser's set_defaults)
-    if hasattr(args, "func"):
-        return int(args.func(args))
-
-    # No command specified: default to monitor
-    if args.command is None:
-        return main(["monitor", *argv])
-
-    # Unknown command (should not happen due to argparse)
-    logger.error("Unknown command: %s", args.command)
-    return 1
+    return int(args.func(args))
 
 
 if __name__ == "__main__":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -65,6 +65,56 @@ def test_main_combine_command(tmp_path: Path) -> None:
     assert cli.main(["combine", str(input_file), "-o", str(tmp_path / "output.pftrace")]) == 0
 
 
+def test_main_no_subcommand_exits_2(capsys: pytest.CaptureFixture[str]) -> None:
+    from gcmon.cli import main as cli
+
+    with pytest.raises(SystemExit) as excinfo:
+        cli.main([])
+
+    assert excinfo.value.code == 2
+    captured = capsys.readouterr()
+    assert "the following arguments are required: command" in captured.err
+    for subcommand in ("monitor", "combine", "run"):
+        assert subcommand in captured.err
+
+
+def test_main_invalid_subcommand_exits_2(capsys: pytest.CaptureFixture[str]) -> None:
+    from gcmon.cli import main as cli
+
+    with pytest.raises(SystemExit) as excinfo:
+        cli.main(["12345"])
+
+    assert excinfo.value.code == 2
+    captured = capsys.readouterr()
+    assert "invalid choice: '12345'" in captured.err
+
+
+def test_main_version_exits_0(capsys: pytest.CaptureFixture[str]) -> None:
+    from gcmon.cli import main as cli
+
+    with pytest.raises(SystemExit) as excinfo:
+        cli.main(["--version"])
+
+    assert excinfo.value.code == 0
+
+
+def test_main_subcommands_dispatch(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    from gcmon.cli import main as cli
+
+    calls: list[str] = []
+    monkeypatch.setattr("gcmon.cli.commands.monitor_cmd.cmd_monitor", lambda args: calls.append("monitor") or 0)
+    assert cli.main(["monitor", "12345"]) == 0
+    assert calls == ["monitor"]
+
+    monkeypatch.setattr("gcmon.cli.commands.run_cmd.cmd_run", lambda args: calls.append("run") or 0)
+    assert cli.main(["run", "-m", "timeit"]) == 0
+    assert calls == ["monitor", "run"]
+
+    monkeypatch.setattr("gcmon.cli.commands.convert_cmd.cmd_combine", lambda args: calls.append("combine") or 0)
+    assert cli.main(["combine", str(tmp_path / "in.jsonl"), "-o", str(tmp_path / "out.pftrace")]) == 0
+    assert calls == ["monitor", "run", "combine"]
+
+
 # =============================================================================
 # CLI Help Tests
 # =============================================================================

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -102,15 +102,28 @@ def test_main_subcommands_dispatch(monkeypatch: pytest.MonkeyPatch, tmp_path: Pa
     from gcmon.cli import main as cli
 
     calls: list[str] = []
-    monkeypatch.setattr("gcmon.cli.commands.monitor_cmd.cmd_monitor", lambda args: calls.append("monitor") or 0)
+
+    def mock_monitor(args: object) -> int:
+        calls.append("monitor")
+        return 0
+
+    def mock_run(args: object) -> int:
+        calls.append("run")
+        return 0
+
+    def mock_combine(args: object) -> int:
+        calls.append("combine")
+        return 0
+
+    monkeypatch.setattr("gcmon.cli.commands.monitor_cmd.cmd_monitor", mock_monitor)
     assert cli.main(["monitor", "12345"]) == 0
     assert calls == ["monitor"]
 
-    monkeypatch.setattr("gcmon.cli.commands.run_cmd.cmd_run", lambda args: calls.append("run") or 0)
+    monkeypatch.setattr("gcmon.cli.commands.run_cmd.cmd_run", mock_run)
     assert cli.main(["run", "-m", "timeit"]) == 0
     assert calls == ["monitor", "run"]
 
-    monkeypatch.setattr("gcmon.cli.commands.convert_cmd.cmd_combine", lambda args: calls.append("combine") or 0)
+    monkeypatch.setattr("gcmon.cli.commands.convert_cmd.cmd_combine", mock_combine)
     assert cli.main(["combine", str(tmp_path / "in.jsonl"), "-o", str(tmp_path / "out.pftrace")]) == 0
     assert calls == ["monitor", "run", "combine"]
 


### PR DESCRIPTION
Closes #143. Part of #142.

## Summary

`gcmon` with no subcommand used to print an `AttributeError` traceback (`'Namespace' object has no attribute 'verbose'`), while `gcmon 12345` exited 2 with an invalid-choice message. This PR makes the subcommand mandatory in the argparse parser, which produces a consistent usage message for both cases, and deletes the dead fallback dispatch code in `main()`.

## Changes

1. **Mandatory subcommand**:
   - In `src/gcmon/cli/main.py:_create_parser()`, set `required=True` on `parser.add_subparsers(dest="command", required=True, help="Available commands")`.
2. **Delete dead fallback code**:
   - In `src/gcmon/cli/main.py:main()`, removed `if hasattr(args, "func")`, the dead fallback `if args.command is None`, and the `logger.error("Unknown command: ...")` block.
   - Replaced with direct `return int(args.func(args))` since all subparsers (`monitor`, `combine`, `run`) define `func` defaults.
   - Removed unused module-level `logger = logging.getLogger("gcmon")`.
3. **Tests (`tests/test_cli.py`)**:
   - `test_main_no_subcommand_exits_2`: asserts `main([])` raises `SystemExit` with `code == 2` and usage error naming the commands.
   - `test_main_invalid_subcommand_exits_2`: asserts `main(["12345"])` raises `SystemExit` with `code == 2` and invalid-choice error.
   - `test_main_version_exits_0`: asserts `main(["--version"])` exits with `code == 0`.
   - `test_main_subcommands_dispatch`: pins that `monitor`, `run`, and `combine` subcommands dispatch to their handlers.
4. **CHANGELOG**:
   - Added entry under `## WIP` -> `### Bugfixes`.

## Verification

- `main([])` exits 2 with `gcmon: error: the following arguments are required: command`
- `main(["12345"])` exits 2 with `gcmon: error: argument command: invalid choice: '12345'`
- `main(["--version"])` exits 0
- `ruff check src tests` passes cleanly.
